### PR TITLE
Return proper 404 error when hitting wrong route

### DIFF
--- a/pkg/api/internal/stytch.go
+++ b/pkg/api/internal/stytch.go
@@ -108,6 +108,14 @@ func (c *Client) RawRequest(
 		return io.ReadAll(res.Body)
 	}
 
+	if res.StatusCode == 404 {
+		err := stytcherror.Error{
+			StatusCode:   res.StatusCode,
+			ErrorMessage: "Not found.",
+		}
+		return nil, err
+	}
+
 	// Attempt to unmarshal into Stytch error format
 	var stytchErr stytcherror.Error
 	if err = json.NewDecoder(res.Body).Decode(&stytchErr); err != nil {


### PR DESCRIPTION
Not doing this makes a 404 return an error in unmarshalling the response, since a 404 response has no body. 

In theory we should rarely hit this because all the routes are hard-coded, but I think it's still better to return a 404 than a Json marshal error.