### PR TITLE
Fix go mod path for v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 # Go workspace file
 go.work
 go.work.sum
+
+# IDE
+.idea/*

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stytchauth/stytch-management-go/v1
+module github.com/stytchauth/stytch-management-go
 
 go 1.18
 

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -3,7 +3,7 @@ package api
 import (
 	"net/http"
 
-	"github.com/stytchauth/stytch-management-go/v1/pkg/api/internal"
+	"github.com/stytchauth/stytch-management-go/pkg/api/internal"
 )
 
 // This is the main entrypoint for interacting with the Stytch Management API

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/api"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/pkg/api"
+	"github.com/stytchauth/stytch-management-go/pkg/models/projects"
 )
 
 func ptr[T any](v T) *T {

--- a/pkg/api/emailtemplates.go
+++ b/pkg/api/emailtemplates.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-management-go/v1/pkg/api/internal"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/emailtemplates"
+	"github.com/stytchauth/stytch-management-go/pkg/api/internal"
+	"github.com/stytchauth/stytch-management-go/pkg/models/emailtemplates"
 )
 
 type EmailTemplatesClient struct {

--- a/pkg/api/emailtemplates_test.go
+++ b/pkg/api/emailtemplates_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/emailtemplates"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/pkg/models/emailtemplates"
+	"github.com/stytchauth/stytch-management-go/pkg/models/projects"
 )
 
 func randomID(t *testing.T) string {

--- a/pkg/api/internal/stytch.go
+++ b/pkg/api/internal/stytch.go
@@ -10,8 +10,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/stytchauth/stytch-management-go/v1/pkg/stytcherror"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/version"
+	"github.com/stytchauth/stytch-management-go/pkg/stytcherror"
+	"github.com/stytchauth/stytch-management-go/pkg/version"
 )
 
 type ClientConfig struct {

--- a/pkg/api/jwttemplates.go
+++ b/pkg/api/jwttemplates.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-management-go/v1/pkg/api/internal"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/jwttemplates"
+	"github.com/stytchauth/stytch-management-go/pkg/api/internal"
+	"github.com/stytchauth/stytch-management-go/pkg/models/jwttemplates"
 )
 
 type JWTTemplatesClient struct {

--- a/pkg/api/jwttemplates_test.go
+++ b/pkg/api/jwttemplates_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/jwttemplates"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/pkg/models/jwttemplates"
+	"github.com/stytchauth/stytch-management-go/pkg/models/projects"
 )
 
 func TestJWTTemplatesClient_Set(t *testing.T) {

--- a/pkg/api/passwordstrengthconfig.go
+++ b/pkg/api/passwordstrengthconfig.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-management-go/v1/pkg/api/internal"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/passwordstrengthconfig"
+	"github.com/stytchauth/stytch-management-go/pkg/api/internal"
+	"github.com/stytchauth/stytch-management-go/pkg/models/passwordstrengthconfig"
 )
 
 type PasswordStrengthConfigClient struct {

--- a/pkg/api/passwordstrengthconfig_test.go
+++ b/pkg/api/passwordstrengthconfig_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/passwordstrengthconfig"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/pkg/models/passwordstrengthconfig"
+	"github.com/stytchauth/stytch-management-go/pkg/models/projects"
 )
 
 func Test_PasswordStrengthConfigGet(t *testing.T) {

--- a/pkg/api/projectmetrics.go
+++ b/pkg/api/projectmetrics.go
@@ -3,8 +3,8 @@ package api
 import (
 	"context"
 
-	"github.com/stytchauth/stytch-management-go/v1/pkg/api/internal"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/projectmetrics"
+	"github.com/stytchauth/stytch-management-go/pkg/api/internal"
+	"github.com/stytchauth/stytch-management-go/pkg/models/projectmetrics"
 )
 
 type ProjectMetricsClient struct {

--- a/pkg/api/projectmetrics_test.go
+++ b/pkg/api/projectmetrics_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/projectmetrics"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/pkg/models/projectmetrics"
+	"github.com/stytchauth/stytch-management-go/pkg/models/projects"
 )
 
 // We currently have no way of creating users/orgs/members *within* the project

--- a/pkg/api/projects.go
+++ b/pkg/api/projects.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-management-go/v1/pkg/api/internal"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/pkg/api/internal"
+	"github.com/stytchauth/stytch-management-go/pkg/models/projects"
 )
 
 type ProjectsClient struct {

--- a/pkg/api/projects_test.go
+++ b/pkg/api/projects_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/pkg/models/projects"
 )
 
 func Test_ProjectsCreate(t *testing.T) {

--- a/pkg/api/publictokens.go
+++ b/pkg/api/publictokens.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-management-go/v1/pkg/api/internal"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/publictokens"
+	"github.com/stytchauth/stytch-management-go/pkg/api/internal"
+	"github.com/stytchauth/stytch-management-go/pkg/models/publictokens"
 )
 
 type PublicTokensClient struct {

--- a/pkg/api/publictokens_test.go
+++ b/pkg/api/publictokens_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/projects"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/publictokens"
+	"github.com/stytchauth/stytch-management-go/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/pkg/models/publictokens"
 )
 
 func TestPublicTokensClient_CreatePublicToken(t *testing.T) {

--- a/pkg/api/rbacpolicy.go
+++ b/pkg/api/rbacpolicy.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-management-go/v1/pkg/api/internal"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/rbacpolicy"
+	"github.com/stytchauth/stytch-management-go/pkg/api/internal"
+	"github.com/stytchauth/stytch-management-go/pkg/models/rbacpolicy"
 )
 
 type RBACPolicyClient struct {

--- a/pkg/api/rbacpolicy_test.go
+++ b/pkg/api/rbacpolicy_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/projects"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/rbacpolicy"
+	"github.com/stytchauth/stytch-management-go/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/pkg/models/rbacpolicy"
 )
 
 func getTestPolicy(t *testing.T) rbacpolicy.Policy {

--- a/pkg/api/redirecturls.go
+++ b/pkg/api/redirecturls.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-management-go/v1/pkg/api/internal"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/redirecturls"
+	"github.com/stytchauth/stytch-management-go/pkg/api/internal"
+	"github.com/stytchauth/stytch-management-go/pkg/models/redirecturls"
 )
 
 type RedirectURLsClient struct {

--- a/pkg/api/redirecturls_test.go
+++ b/pkg/api/redirecturls_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/projects"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/redirecturls"
+	"github.com/stytchauth/stytch-management-go/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/pkg/models/redirecturls"
 )
 
 func (c *testClient) createRedirectURL(projectID string, url string, redirectType redirecturls.RedirectType) {

--- a/pkg/api/sdk.go
+++ b/pkg/api/sdk.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-management-go/v1/pkg/api/internal"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/sdk"
+	"github.com/stytchauth/stytch-management-go/pkg/api/internal"
+	"github.com/stytchauth/stytch-management-go/pkg/models/sdk"
 )
 
 type SDKClient struct {

--- a/pkg/api/sdk_test.go
+++ b/pkg/api/sdk_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/projects"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/sdk"
+	"github.com/stytchauth/stytch-management-go/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/pkg/models/sdk"
 )
 
 func makeTestConsumerConfig(t *testing.T) sdk.ConsumerConfig {

--- a/pkg/api/secrets.go
+++ b/pkg/api/secrets.go
@@ -3,8 +3,8 @@ package api
 import (
 	"context"
 
-	"github.com/stytchauth/stytch-management-go/v1/pkg/api/internal"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/secrets"
+	"github.com/stytchauth/stytch-management-go/pkg/api/internal"
+	"github.com/stytchauth/stytch-management-go/pkg/models/secrets"
 )
 
 type SecretsClient struct {

--- a/pkg/api/secrets_test.go
+++ b/pkg/api/secrets_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/projects"
-	"github.com/stytchauth/stytch-management-go/v1/pkg/models/secrets"
+	"github.com/stytchauth/stytch-management-go/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/pkg/models/secrets"
 )
 
 func TestSecretsClient_Create(t *testing.T) {


### PR DESCRIPTION
Fixes BACK-4217

When installing the package, we're running into issues.

```
go get github.com/stytchauth/stytch-management-go
go: github.com/stytchauth/stytch-management-go@v1.0.0: invalid version: go.mod has malformed module path "github.com/stytchauth/stytch-management-go/v1" at revision v1.0.0
```

We should not have `v1` in the go mod path (only for versions >1). (See the exact opposite of this in https://github.com/stytchauth/stytch-go/pull/30)