### PR TITLE
Temporarily remove CrossOrgPasswords until fully published

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -39,5 +39,4 @@ jobs:
         if: steps.diff.outputs.diff != 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Don't actually start publishing releases yet
-        run: echo gh release create ${{ steps.version.outputs.release_tag }} --generate-notes
+        run: gh release create ${{ steps.version.outputs.release_tag }} --generate-notes

--- a/pkg/api/projects_test.go
+++ b/pkg/api/projects_test.go
@@ -77,13 +77,11 @@ func Test_ProjectsUpdate(t *testing.T) {
 
 	// Act
 	resp, err := client.Projects.Update(ctx, projects.UpdateRequest{
-		ProjectID:            project.LiveProjectID,
-		Name:                 newProjectName,
-		UseCrossOrgPasswords: !project.UseCrossOrgPasswords,
+		ProjectID: project.LiveProjectID,
+		Name:      newProjectName,
 	})
 
 	// Assert
 	assert.NoError(t, err)
 	assert.Equal(t, newProjectName, resp.Project.Name)
-	assert.Equal(t, !project.UseCrossOrgPasswords, resp.Project.UseCrossOrgPasswords)
 }

--- a/pkg/models/projects/types.go
+++ b/pkg/models/projects/types.go
@@ -25,8 +25,6 @@ type Project struct {
 	Vertical Vertical `json:"vertical"`
 	// CreatedAt is the ISO-8601 timestamp for when the project was created
 	CreatedAt time.Time `json:"created_at"`
-	// UseCrossOrgPasswords is for whether we want to enable cross-org passwords for the project
-	UseCrossOrgPasswords bool `json:"use_cross_org_passwords"`
 }
 
 type CreateRequest struct {
@@ -87,8 +85,6 @@ type UpdateRequest struct {
 	ProjectID string `json:"project_id"`
 	// Name is the new name for the project
 	Name string `json:"name"`
-	// UseCrossOrgPasswords is for whether we want to enable cross-org passwords for the project
-	UseCrossOrgPasswords bool `json:"use_cross_org_passwords"`
 }
 
 type UpdateResponse struct {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "0.1.0"
+const Version = "1.0.2"


### PR DESCRIPTION
Title. I'm also advancing the version internally to 1.0.2 -- although this is still a beta product, the release is "stable" for the management-go client.

Additionally, we had previously released 1.0.0 and 1.0.1, so we *need* to advance the version, unfortunately.