### PR TITLE
[AUTH-5155] Stop overwriting Cross-org passwords + UserImpersonation Settings

### DIFF
--- a/pkg/api/projects_test.go
+++ b/pkg/api/projects_test.go
@@ -88,10 +88,10 @@ func Test_ProjectsUpdate(t *testing.T) {
 
 	// Act
 	resp, err := client.Projects.Update(ctx, projects.UpdateRequest{
-		ProjectID:                project.LiveProjectID,
-		Name:                     newProjectName,
-		UserImpersonationEnabled: ptr(true),
-		UseCrossOrgPasswords:     ptr(true),
+		ProjectID:                    project.LiveProjectID,
+		Name:                         newProjectName,
+		LiveUserImpersonationEnabled: ptr(true),
+		LiveUseCrossOrgPasswords:     ptr(true),
 	})
 
 	// Assert
@@ -113,9 +113,9 @@ func Test_ProjectsUpdateDoesNotOverwriteValues(t *testing.T) {
 	resp, err := client.Projects.Update(ctx, projects.UpdateRequest{
 		ProjectID:                    project.LiveProjectID,
 		Name:                         newProjectName,
-		UserImpersonationEnabled:     ptr(true),
+		LiveUserImpersonationEnabled: ptr(true),
 		TestUserImpersonationEnabled: ptr(true),
-		UseCrossOrgPasswords:         ptr(true),
+		LiveUseCrossOrgPasswords:     ptr(true),
 		TestUseCrossOrgPasswords:     ptr(true),
 	})
 

--- a/pkg/api/projects_test.go
+++ b/pkg/api/projects_test.go
@@ -90,10 +90,49 @@ func Test_ProjectsUpdate(t *testing.T) {
 	resp, err := client.Projects.Update(ctx, projects.UpdateRequest{
 		ProjectID:                project.LiveProjectID,
 		Name:                     newProjectName,
-		UserImpersonationEnabled: true,
-		UseCrossOrgPasswords:     true,
+		UserImpersonationEnabled: ptr(true),
+		UseCrossOrgPasswords:     ptr(true),
 	})
 
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, newProjectName, resp.Project.Name)
+	assert.True(t, resp.Project.LiveUserImpersonationEnabled)
+	assert.True(t, resp.Project.LiveCrossOrgPasswordsEnabled)
+}
+
+func Test_ProjectsUpdateDoesNotOverwriteValues(t *testing.T) {
+	// Arrange
+	client := NewTestClient(t)
+	project := client.DisposableProject(projects.VerticalB2B)
+	assert.False(t, project.LiveCrossOrgPasswordsEnabled)
+	ctx := context.Background()
+	newProjectName := "The new project v2"
+
+	// Act
+	resp, err := client.Projects.Update(ctx, projects.UpdateRequest{
+		ProjectID:                    project.LiveProjectID,
+		Name:                         newProjectName,
+		UserImpersonationEnabled:     ptr(true),
+		TestUserImpersonationEnabled: ptr(true),
+		UseCrossOrgPasswords:         ptr(true),
+		TestUseCrossOrgPasswords:     ptr(true),
+	})
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Equal(t, newProjectName, resp.Project.Name)
+	assert.True(t, resp.Project.LiveUserImpersonationEnabled)
+	assert.True(t, resp.Project.TestUserImpersonationEnabled)
+	assert.True(t, resp.Project.LiveCrossOrgPasswordsEnabled)
+	assert.True(t, resp.Project.TestCrossOrgPasswordsEnabled)
+
+	// Act again to check if the values are not overwritten
+	newProjectName = "The new project v2.1"
+	resp, err = client.Projects.Update(ctx, projects.UpdateRequest{
+		ProjectID: project.LiveProjectID,
+		Name:      newProjectName,
+	})
 	// Assert
 	assert.NoError(t, err)
 	assert.Equal(t, newProjectName, resp.Project.Name)

--- a/pkg/models/projects/types.go
+++ b/pkg/models/projects/types.go
@@ -108,12 +108,12 @@ type UpdateRequest struct {
 	ProjectID string `json:"project_id"`
 	// Name is the new name for the project
 	Name string `json:"name"`
-	// UserImpersonationEnabled is a boolean indicating whether user impersonation is enabled for the project
-	UserImpersonationEnabled *bool `json:"live_user_impersonation_enabled"`
+	// LiveUserImpersonationEnabled is a boolean indicating whether user impersonation is enabled for the project
+	LiveUserImpersonationEnabled *bool `json:"live_user_impersonation_enabled"`
 	// TestUserImpersonationEnabled is a boolean indicating whether user impersonation is enabled for the test project
 	TestUserImpersonationEnabled *bool `json:"test_user_impersonation_enabled"`
-	// UseCrossOrgPasswords is a boolean indicating whether the project uses cross-org passwords
-	UseCrossOrgPasswords *bool `json:"live_use_cross_org_passwords"`
+	// LiveUseCrossOrgPasswords is a boolean indicating whether the project uses cross-org passwords
+	LiveUseCrossOrgPasswords *bool `json:"live_use_cross_org_passwords"`
 	// TestUseCrossOrgPasswords is a boolean indicating whether the test project uses cross-org passwords
 	TestUseCrossOrgPasswords *bool `json:"test_use_cross_org_passwords"`
 }

--- a/pkg/models/projects/types.go
+++ b/pkg/models/projects/types.go
@@ -109,9 +109,13 @@ type UpdateRequest struct {
 	// Name is the new name for the project
 	Name string `json:"name"`
 	// UserImpersonationEnabled is a boolean indicating whether user impersonation is enabled for the project
-	UserImpersonationEnabled bool `json:"user_impersonation_enabled"`
+	UserImpersonationEnabled *bool `json:"live_user_impersonation_enabled"`
+	// TestUserImpersonationEnabled is a boolean indicating whether user impersonation is enabled for the test project
+	TestUserImpersonationEnabled *bool `json:"test_user_impersonation_enabled"`
 	// UseCrossOrgPasswords is a boolean indicating whether the project uses cross-org passwords
-	UseCrossOrgPasswords bool `json:"use_cross_org_passwords"`
+	UseCrossOrgPasswords *bool `json:"live_use_cross_org_passwords"`
+	// TestUseCrossOrgPasswords is a boolean indicating whether the test project uses cross-org passwords
+	TestUseCrossOrgPasswords *bool `json:"test_use_cross_org_passwords"`
 }
 
 type UpdateResponse struct {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "1.4.2"
+const Version = "2.0.0"


### PR DESCRIPTION
Updates for the following:

1) Allows setting both Test and Live settings for CrossOrgPasswords + UserImpersonation
2) Fixes bug where not providing a value for CrossOrgPasswords or UserImpersonation treated them as False values.