### PR TITLE
Disable HTTPOnlyCookies enabling in test since it needs active cname

### DIFF
--- a/pkg/api/sdk_test.go
+++ b/pkg/api/sdk_test.go
@@ -66,7 +66,7 @@ func makeTestConsumerConfig(t *testing.T) sdk.ConsumerConfig {
 			PKCERequiredForPasswordResets: true,
 		},
 		Cookies: &sdk.ConsumerCookiesConfig{
-			HttpOnlyCookies: sdk.HttpOnlyCookiesSettingEnabled,
+			HttpOnlyCookies: sdk.HttpOnlyCookiesSettingDisabled,
 		},
 	}
 }
@@ -121,7 +121,7 @@ func makeTestB2BConfig(t *testing.T) sdk.B2BConfig {
 			PKCERequiredForPasswordResets: false,
 		},
 		Cookies: &sdk.B2BCookiesConfig{
-			HttpOnlyCookies: sdk.HttpOnlyCookiesSettingEnabled,
+			HttpOnlyCookies: sdk.HttpOnlyCookiesSettingDisabled,
 		},
 	}
 }


### PR DESCRIPTION
## Description

Enabling or enforcing HTTPOnlyCookies needs the project to have a valid CNAME. Since we don't do this in tests, let's not attempt to test enabling this setting. 

## Tests

Unit tests