### PR TITLE
[allowlist] [BACK-4733] Add allowlist endpoints

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -15,6 +15,7 @@ type API struct {
 
 	// These are the clients for all the different
 	// resources available via the management API
+	CountryCodeAllowlist   *CountryCodeAllowlistClient
 	EmailTemplates         *EmailTemplatesClient
 	JWTTemplates           *JWTTemplatesClient
 	PasswordStrengthConfig *PasswordStrengthConfigClient
@@ -72,6 +73,7 @@ func NewClient(workspaceKeyID string, workspaceKeySecret string, opts ...APIOpti
 
 	return &API{
 		client:                 client,
+		CountryCodeAllowlist:   newCountryCodeAllowlistClient(client),
 		EmailTemplates:         newEmailTemplatesClient(client),
 		JWTTemplates:           newJWTTemplatesClient(client),
 		PasswordStrengthConfig: newPasswordStrengthConfigClient(client),
@@ -85,7 +87,7 @@ func NewClient(workspaceKeyID string, workspaceKeySecret string, opts ...APIOpti
 	}
 }
 
-// NewClient creates a new API client with an access token.
+// NewAccessTokenClient creates a new API client with an access token.
 func NewAccessTokenClient(accessToken string, opts ...APIOption) *API {
 	c := apiConfig{
 		baseURI:    defaultBaseURI,
@@ -104,6 +106,7 @@ func NewAccessTokenClient(accessToken string, opts ...APIOption) *API {
 
 	return &API{
 		client:                 client,
+		CountryCodeAllowlist:   newCountryCodeAllowlistClient(client),
 		EmailTemplates:         newEmailTemplatesClient(client),
 		JWTTemplates:           newJWTTemplatesClient(client),
 		PasswordStrengthConfig: newPasswordStrengthConfigClient(client),

--- a/pkg/api/countrycodeallowlist.go
+++ b/pkg/api/countrycodeallowlist.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/stytchauth/stytch-management-go/v2/pkg/api/internal"
+	cca "github.com/stytchauth/stytch-management-go/v2/pkg/models/countrycodeallowlist"
+	"net/http"
+)
+
+type CountryCodeAllowlistClient struct {
+	client *internal.Client
+}
+
+func newCountryCodeAllowlistClient(c *internal.Client) *CountryCodeAllowlistClient {
+	return &CountryCodeAllowlistClient{client: c}
+}
+
+func (c *CountryCodeAllowlistClient) GetAllowedSMSCountryCodes(
+	ctx context.Context,
+	body *cca.GetAllowedSMSCountryCodesRequest,
+) (*cca.GetAllowedSMSCountryCodesResponse, error) {
+	var resp cca.GetAllowedSMSCountryCodesResponse
+	err := c.client.NewRequest(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("/v1/projects/%s/allowed_country_codes/sms", body.ProjectID),
+		nil,
+		nil,
+		&resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, err
+}
+
+func (c *CountryCodeAllowlistClient) GetAllowedWhatsAppCountryCodes(
+	ctx context.Context,
+	body *cca.GetAllowedWhatsAppCountryCodesRequest,
+) (*cca.GetAllowedWhatsAppCountryCodesResponse, error) {
+	var resp cca.GetAllowedWhatsAppCountryCodesResponse
+	err := c.client.NewRequest(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("/v1/projects/%s/allowed_country_codes/whatsapp", body.ProjectID),
+		nil,
+		nil,
+		&resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, err
+}
+
+func (c *CountryCodeAllowlistClient) SetAllowedSMSCountryCodes(
+	ctx context.Context,
+	body *cca.SetAllowedSMSCountryCodesRequest,
+) (*cca.SetAllowedSMSCountryCodesResponse, error) {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp cca.SetAllowedSMSCountryCodesResponse
+	err = c.client.NewRequest(
+		ctx,
+		http.MethodPost,
+		fmt.Sprintf("/v1/projects/%s/allowed_country_codes/sms", body.ProjectID),
+		nil,
+		jsonBody,
+		&resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, err
+}
+
+func (c *CountryCodeAllowlistClient) SetAllowedWhatsAppCountryCodes(
+	ctx context.Context,
+	body *cca.SetAllowedWhatsAppCountryCodesRequest,
+) (*cca.SetAllowedWhatsAppCountryCodesResponse, error) {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp cca.SetAllowedWhatsAppCountryCodesResponse
+	err = c.client.NewRequest(
+		ctx,
+		http.MethodPost,
+		fmt.Sprintf("/v1/projects/%s/allowed_country_codes/whatsapp", body.ProjectID),
+		nil,
+		jsonBody,
+		&resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, err
+}

--- a/pkg/api/countrycodeallowlist_test.go
+++ b/pkg/api/countrycodeallowlist_test.go
@@ -1,0 +1,207 @@
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cca "github.com/stytchauth/stytch-management-go/v2/pkg/models/countrycodeallowlist"
+	"github.com/stytchauth/stytch-management-go/v2/pkg/models/projects"
+)
+
+func TestCountryCodeAllowlistClient_GetAllowedSMSCountryCodes(t *testing.T) {
+	t.Run("default country codes", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+		expected := []string{"CA", "US"}
+
+		// Act
+		resp, err := client.CountryCodeAllowlist.GetAllowedSMSCountryCodes(ctx,
+			&cca.GetAllowedSMSCountryCodesRequest{
+				ProjectID: project.LiveProjectID,
+			})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, expected, resp.CountryCodes)
+	})
+	t.Run("get country codes", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+		expected := []string{"CA", "MX", "US"}
+		_, err := client.CountryCodeAllowlist.SetAllowedSMSCountryCodes(ctx,
+			&cca.SetAllowedSMSCountryCodesRequest{
+				ProjectID:    project.LiveProjectID,
+				CountryCodes: expected,
+			})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.CountryCodeAllowlist.GetAllowedSMSCountryCodes(ctx,
+			&cca.GetAllowedSMSCountryCodesRequest{
+				ProjectID: project.LiveProjectID,
+			})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, expected, resp.CountryCodes)
+	})
+	t.Run("project does not exist", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.CountryCodeAllowlist.GetAllowedSMSCountryCodes(ctx,
+			&cca.GetAllowedSMSCountryCodesRequest{
+				ProjectID: "project-does-not-exist",
+			})
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes(t *testing.T) {
+	t.Run("default country codes", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+		expected := []string{"CA", "US"}
+
+		// Act
+		resp, err := client.CountryCodeAllowlist.GetAllowedWhatsAppCountryCodes(ctx,
+			&cca.GetAllowedWhatsAppCountryCodesRequest{
+				ProjectID: project.LiveProjectID,
+			})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, expected, resp.CountryCodes)
+	})
+	t.Run("get country codes", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+		expected := []string{"CA", "MX", "US"}
+		_, err := client.CountryCodeAllowlist.SetAllowedWhatsAppCountryCodes(ctx,
+			&cca.SetAllowedWhatsAppCountryCodesRequest{
+				ProjectID:    project.LiveProjectID,
+				CountryCodes: expected,
+			})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.CountryCodeAllowlist.GetAllowedWhatsAppCountryCodes(ctx,
+			&cca.GetAllowedWhatsAppCountryCodesRequest{
+				ProjectID: project.LiveProjectID,
+			})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, expected, resp.CountryCodes)
+	})
+	t.Run("project does not exist", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.CountryCodeAllowlist.GetAllowedWhatsAppCountryCodes(ctx,
+			&cca.GetAllowedWhatsAppCountryCodesRequest{
+				ProjectID: "project-does-not-exist",
+			})
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestCountryCodeAllowlistClient_SetAllowedSMSCountryCodes(t *testing.T) {
+	t.Run("get country codes", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+		expected := []string{"CA", "MX", "US"}
+
+		// Act
+		_, err := client.CountryCodeAllowlist.SetAllowedSMSCountryCodes(ctx,
+			&cca.SetAllowedSMSCountryCodesRequest{
+				ProjectID:    project.LiveProjectID,
+				CountryCodes: expected,
+			})
+
+		// Assert
+		assert.NoError(t, err)
+		resp, err := client.CountryCodeAllowlist.GetAllowedSMSCountryCodes(ctx,
+			&cca.GetAllowedSMSCountryCodesRequest{
+				ProjectID: project.LiveProjectID,
+			})
+		require.NoError(t, err)
+		assert.Equal(t, expected, resp.CountryCodes)
+	})
+	t.Run("project does not exist", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		ctx := context.Background()
+
+		// Act
+		_, err := client.CountryCodeAllowlist.SetAllowedSMSCountryCodes(ctx,
+			&cca.SetAllowedSMSCountryCodesRequest{
+				ProjectID:    "project-does-not-exist",
+				CountryCodes: []string{"CA", "MX", "US"},
+			})
+
+		assert.Error(t, err)
+	})
+}
+
+func TestCountryCodeAllowlistClient_SetAllowedWhatsAppCountryCodes(t *testing.T) {
+	t.Run("get country codes", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+		expected := []string{"CA", "MX", "US"}
+
+		// Act
+		_, err := client.CountryCodeAllowlist.SetAllowedWhatsAppCountryCodes(ctx,
+			&cca.SetAllowedWhatsAppCountryCodesRequest{
+				ProjectID:    project.LiveProjectID,
+				CountryCodes: expected,
+			})
+
+		// Assert
+		assert.NoError(t, err)
+		resp, err := client.CountryCodeAllowlist.GetAllowedWhatsAppCountryCodes(ctx,
+			&cca.GetAllowedWhatsAppCountryCodesRequest{
+				ProjectID: project.LiveProjectID,
+			})
+		require.NoError(t, err)
+		assert.Equal(t, expected, resp.CountryCodes)
+	})
+	t.Run("project does not exist", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		ctx := context.Background()
+
+		// Act
+		_, err := client.CountryCodeAllowlist.SetAllowedWhatsAppCountryCodes(ctx,
+			&cca.SetAllowedWhatsAppCountryCodesRequest{
+				ProjectID:    "project-does-not-exist",
+				CountryCodes: []string{"CA", "MX", "US"},
+			})
+
+		assert.Error(t, err)
+	})
+}

--- a/pkg/models/countrycodeallowlist/types.go
+++ b/pkg/models/countrycodeallowlist/types.go
@@ -1,0 +1,49 @@
+package countrycodeallowlist
+
+type GetAllowedSMSCountryCodesRequest struct {
+	// ProjectID is the unique ID of the project for which to retrieve allowed SMS country codes.
+	ProjectID string `json:"project_id"`
+}
+
+type GetAllowedSMSCountryCodesResponse struct {
+	// RequestID is a unique identifier to help with debugging the request.
+	RequestID string `json:"request_id"`
+	// CountryCodes is a list of country codes that are allowed for SMS.
+	CountryCodes []string `json:"country_codes"`
+}
+
+type GetAllowedWhatsAppCountryCodesRequest struct {
+	// ProjectID is the unique ID of the project for which to retrieve allowed WhatsApp country codes.
+	ProjectID string `json:"project_id"`
+}
+
+type GetAllowedWhatsAppCountryCodesResponse struct {
+	// RequestID is a unique identifier to help with debugging the request.
+	RequestID string `json:"request_id"`
+	// CountryCodes is a list of country codes that are allowed for WhatsApp.
+	CountryCodes []string `json:"country_codes"`
+}
+
+type SetAllowedSMSCountryCodesRequest struct {
+	// ProjectID is the unique ID of the project for which to set allowed SMS country codes.
+	ProjectID string `json:"-"`
+	// CountryCodes is a list of country codes to set as allowed for SMS.
+	CountryCodes []string `json:"country_codes"`
+}
+
+type SetAllowedSMSCountryCodesResponse struct {
+	// RequestID is a unique identifier to help with debugging the request.
+	RequestID string `json:"request_id"`
+}
+
+type SetAllowedWhatsAppCountryCodesRequest struct {
+	// ProjectID is the unique ID of the project for which to set allowed WhatsApp country codes.
+	ProjectID string `json:"-"`
+	// CountryCodes is a list of country codes to set as allowed for WhatsApp.
+	CountryCodes []string `json:"country_codes"`
+}
+
+type SetAllowedWhatsAppCountryCodesResponse struct {
+	// RequestID is a unique identifier to help with debugging the request.
+	RequestID string `json:"request_id"`
+}


### PR DESCRIPTION
See title.

There are a few differences from other Management endpoints:
1. The allowlist responses do not contain `StatusCode`. This is fine because `RawRequest` nulls out the response in the case of an error anyway, so the only time we have a status code is on status codes 200 and 201.
2. The allowlist endpoints return a nil response on error, whereas our other endpoints seem to return an empty response struct. I think we should change our other endpoints to also return a nil response on error, provided we do not break any existing customers.