### PR TITLE
Add user agent suffix opt

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -37,8 +37,9 @@ type apiConfig struct {
 	WorkspaceKeyID     string
 	WorkspaceKeySecret string
 
-	baseURI    string
-	httpClient *http.Client
+	baseURI         string
+	httpClient      *http.Client
+	userAgentSuffix string
 }
 
 type APIOption func(*apiConfig)
@@ -52,6 +53,12 @@ func WithBaseURI(baseURI string) APIOption {
 func WithHTTPClient(client *http.Client) APIOption {
 	return func(a *apiConfig) {
 		a.httpClient = client
+	}
+}
+
+func WithUserAgentSuffix(userAgentSuffix string) APIOption {
+	return func(a *apiConfig) {
+		a.userAgentSuffix = userAgentSuffix
 	}
 }
 
@@ -71,6 +78,7 @@ func NewClient(workspaceKeyID string, workspaceKeySecret string, opts ...APIOpti
 		WorkspaceKeySecret: workspaceKeySecret,
 		BaseURI:            c.baseURI,
 		HTTPClient:         c.httpClient,
+		UserAgentSuffix:    c.userAgentSuffix,
 	})
 
 	return &API{

--- a/pkg/api/internal/stytch.go
+++ b/pkg/api/internal/stytch.go
@@ -20,6 +20,7 @@ type ClientConfig struct {
 	AccessToken        string
 	BaseURI            string
 	HTTPClient         *http.Client
+	UserAgentSuffix    string
 }
 
 type Client struct {
@@ -28,6 +29,7 @@ type Client struct {
 	accessToken        string
 	baseURI            string
 	httpClient         *http.Client
+	userAgentSuffix    string
 }
 
 func NewClient(c ClientConfig) *Client {
@@ -37,6 +39,7 @@ func NewClient(c ClientConfig) *Client {
 		accessToken:        c.AccessToken,
 		baseURI:            c.BaseURI,
 		httpClient:         c.HTTPClient,
+		userAgentSuffix:    c.UserAgentSuffix,
 	}
 }
 
@@ -104,7 +107,11 @@ func (c *Client) RawRequest(
 		panic("unable to set auth header for request")
 	}
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("User-Agent", "Stytch Management Go v"+version.Version)
+	userAgent := "stytch-management-go/" + version.Version
+	if c.userAgentSuffix != "" {
+		userAgent += " " + c.userAgentSuffix
+	}
+	req.Header.Add("User-Agent", userAgent)
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "2.5.0"
+const Version = "2.5.1"


### PR DESCRIPTION
## Description

- Adds the ability to pass in a user agent suffix, separated by a space
- Reformats the user agent for easier parsing once a suffix is added

## Testing

Ran our existing tests, and saw the updated user agent

<img width="324" height="75" alt="image" src="https://github.com/user-attachments/assets/59890f18-68cc-4831-9334-6f01b5752e59" />

Then tested with an additional user agent suffix opt:

```	
opts = append(opts, api.WithUserAgentSuffix("testing-hello/1"))
```

<img width="317" height="65" alt="image" src="https://github.com/user-attachments/assets/28d4421d-8c07-4b9c-bc51-a965d32b74ee" />

