### PR TITLE
Set the release target properly

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -38,4 +38,4 @@ jobs:
         if: steps.diff.outputs.diff != 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create ${{ steps.version.outputs.release_tag }} --generate-notes
+        run: gh release create ${{ steps.version.outputs.release_tag }} --target $GITHUB_SHA --generate-notes

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "2.6.0"
+const Version = "2.7.0"


### PR DESCRIPTION
We weren't using `--target` in `gh release create`, which meant we were publishing from the default branch. 
This fixes it. 
Also bump minor version so that a new release gets cut

TODO: The change in auto-publish.yml also needs to get to `main`