### PR TITLE
[V3] Tests for a couple of services

### DIFF
--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -15,6 +15,11 @@ type testClient struct {
 	*api.API
 }
 
+// These are the names of the first test and live environments created
+// when a new project is created. These are used in tests.
+var LiveEnvironment string = "production"
+var TestEnvironment string = "test"
+
 // NewTestClient is a test helper function that returns a new API client.
 // It relies on the environment variables STYTCH_WORKSPACE_KEY_ID and STYTCH_WORKSPACE_KEY_SECRET being set.
 func NewTestClient(t *testing.T) *testClient {

--- a/pkg/api/countrycodeallowlist_test.go
+++ b/pkg/api/countrycodeallowlist_test.go
@@ -22,7 +22,7 @@ func TestCountryCodeAllowlistClient_GetAllowedSMSCountryCodes(t *testing.T) {
 		resp, err := client.CountryCodeAllowlist.GetAllowedSMSCountryCodes(ctx,
 			&cca.GetAllowedSMSCountryCodesRequest{
 				Project:     project.Project,
-				Environment: "test",
+				Environment: TestEnvironment,
 			})
 
 		// Assert
@@ -38,7 +38,7 @@ func TestCountryCodeAllowlistClient_GetAllowedSMSCountryCodes(t *testing.T) {
 		_, err := client.CountryCodeAllowlist.SetAllowedSMSCountryCodes(ctx,
 			&cca.SetAllowedSMSCountryCodesRequest{
 				Project:      project.Project,
-				Environment:  "test",
+				Environment:  TestEnvironment,
 				CountryCodes: expected,
 			})
 		require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestCountryCodeAllowlistClient_GetAllowedSMSCountryCodes(t *testing.T) {
 		resp, err := client.CountryCodeAllowlist.GetAllowedSMSCountryCodes(ctx,
 			&cca.GetAllowedSMSCountryCodesRequest{
 				Project:     project.Project,
-				Environment: "test",
+				Environment: TestEnvironment,
 			})
 
 		// Assert
@@ -63,7 +63,7 @@ func TestCountryCodeAllowlistClient_GetAllowedSMSCountryCodes(t *testing.T) {
 		resp, err := client.CountryCodeAllowlist.GetAllowedSMSCountryCodes(ctx,
 			&cca.GetAllowedSMSCountryCodesRequest{
 				Project:     "project-does-not-exist",
-				Environment: "test",
+				Environment: TestEnvironment,
 			})
 
 		// Assert
@@ -84,7 +84,7 @@ func TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes(t *testing.T)
 		resp, err := client.CountryCodeAllowlist.GetAllowedWhatsAppCountryCodes(ctx,
 			&cca.GetAllowedWhatsAppCountryCodesRequest{
 				Project:     project.Project,
-				Environment: "test",
+				Environment: TestEnvironment,
 			})
 
 		// Assert
@@ -100,7 +100,7 @@ func TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes(t *testing.T)
 		_, err := client.CountryCodeAllowlist.SetAllowedWhatsAppCountryCodes(ctx,
 			&cca.SetAllowedWhatsAppCountryCodesRequest{
 				Project:      project.Project,
-				Environment:  "test",
+				Environment:  TestEnvironment,
 				CountryCodes: expected,
 			})
 		require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes(t *testing.T)
 		resp, err := client.CountryCodeAllowlist.GetAllowedWhatsAppCountryCodes(ctx,
 			&cca.GetAllowedWhatsAppCountryCodesRequest{
 				Project:     project.Project,
-				Environment: "test",
+				Environment: TestEnvironment,
 			})
 
 		// Assert
@@ -126,7 +126,7 @@ func TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes(t *testing.T)
 		_, err := client.CountryCodeAllowlist.GetAllowedWhatsAppCountryCodes(ctx,
 			&cca.GetAllowedWhatsAppCountryCodesRequest{
 				Project:     project.Project,
-				Environment: "test",
+				Environment: TestEnvironment,
 			})
 
 		// Assert
@@ -141,7 +141,7 @@ func TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes(t *testing.T)
 		resp, err := client.CountryCodeAllowlist.GetAllowedWhatsAppCountryCodes(ctx,
 			&cca.GetAllowedWhatsAppCountryCodesRequest{
 				Project:     "project-does-not-exist",
-				Environment: "test",
+				Environment: TestEnvironment,
 			})
 
 		// Assert
@@ -162,7 +162,7 @@ func TestCountryCodeAllowlistClient_SetAllowedSMSCountryCodes(t *testing.T) {
 		setResp, err := client.CountryCodeAllowlist.SetAllowedSMSCountryCodes(ctx,
 			&cca.SetAllowedSMSCountryCodesRequest{
 				Project:      project.Project,
-				Environment:  "test",
+				Environment:  TestEnvironment,
 				CountryCodes: expected,
 			})
 
@@ -173,7 +173,7 @@ func TestCountryCodeAllowlistClient_SetAllowedSMSCountryCodes(t *testing.T) {
 		getResp, err := client.CountryCodeAllowlist.GetAllowedSMSCountryCodes(ctx,
 			&cca.GetAllowedSMSCountryCodesRequest{
 				Project:     project.Project,
-				Environment: "test",
+				Environment: TestEnvironment,
 			})
 		require.NoError(t, err)
 		assert.Equal(t, expected, getResp.CountryCodes)
@@ -187,7 +187,7 @@ func TestCountryCodeAllowlistClient_SetAllowedSMSCountryCodes(t *testing.T) {
 		_, err := client.CountryCodeAllowlist.SetAllowedSMSCountryCodes(ctx,
 			&cca.SetAllowedSMSCountryCodesRequest{
 				Project:      "project-does-not-exist",
-				Environment:  "test",
+				Environment:  TestEnvironment,
 				CountryCodes: []string{"CA", "MX", "US"},
 			})
 
@@ -207,7 +207,7 @@ func TestCountryCodeAllowlistClient_SetAllowedWhatsAppCountryCodes(t *testing.T)
 		setResp, err := client.CountryCodeAllowlist.SetAllowedWhatsAppCountryCodes(ctx,
 			&cca.SetAllowedWhatsAppCountryCodesRequest{
 				Project:      project.Project,
-				Environment:  "test",
+				Environment:  TestEnvironment,
 				CountryCodes: expected,
 			})
 
@@ -218,7 +218,7 @@ func TestCountryCodeAllowlistClient_SetAllowedWhatsAppCountryCodes(t *testing.T)
 		getResp, err := client.CountryCodeAllowlist.GetAllowedWhatsAppCountryCodes(ctx,
 			&cca.GetAllowedWhatsAppCountryCodesRequest{
 				Project:     project.Project,
-				Environment: "test",
+				Environment: TestEnvironment,
 			})
 		require.NoError(t, err)
 		assert.Equal(t, expected, getResp.CountryCodes)
@@ -233,7 +233,7 @@ func TestCountryCodeAllowlistClient_SetAllowedWhatsAppCountryCodes(t *testing.T)
 		_, err := client.CountryCodeAllowlist.SetAllowedWhatsAppCountryCodes(ctx,
 			&cca.SetAllowedWhatsAppCountryCodesRequest{
 				Project:      project.Project,
-				Environment:  "test",
+				Environment:  TestEnvironment,
 				CountryCodes: []string{"CA", "MX", "US"},
 			})
 
@@ -249,7 +249,7 @@ func TestCountryCodeAllowlistClient_SetAllowedWhatsAppCountryCodes(t *testing.T)
 		_, err := client.CountryCodeAllowlist.SetAllowedWhatsAppCountryCodes(ctx,
 			&cca.SetAllowedWhatsAppCountryCodesRequest{
 				Project:      "project-does-not-exist",
-				Environment:  "test",
+				Environment:  TestEnvironment,
 				CountryCodes: []string{"CA", "MX", "US"},
 			})
 

--- a/pkg/api/eventlogstreaming_test.go
+++ b/pkg/api/eventlogstreaming_test.go
@@ -1,0 +1,439 @@
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/eventlogstreaming"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/projects"
+)
+
+func TestEventLogStreamingClient_Create(t *testing.T) {
+	t.Run("create datadog config", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+			DestinationConfig: eventlogstreaming.DestinationConfig{
+				Datadog: &eventlogstreaming.DatadogConfig{
+					Site:   eventlogstreaming.DatadogSiteUS,
+					APIKey: "1234567890abcdef1234567890abcdef",
+				},
+			},
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, eventlogstreaming.DestinationTypeDatadog, resp.EventLogStreamingConfig.DestinationType)
+		assert.Equal(t, eventlogstreaming.DatadogSiteUS, resp.EventLogStreamingConfig.DestinationConfig.Datadog.Site)
+		assert.Equal(t, "1234567890abcdef1234567890abcdef", resp.EventLogStreamingConfig.DestinationConfig.Datadog.APIKey)
+		assert.Equal(t, eventlogstreaming.StreamingStatusDisabled, resp.EventLogStreamingConfig.StreamingStatus)
+	})
+
+	t.Run("create grafana loki config", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeGrafanaLoki,
+			DestinationConfig: eventlogstreaming.DestinationConfig{
+				GrafanaLoki: &eventlogstreaming.GrafanaLokiConfig{
+					Hostname: "logs-prod-us-central1.grafana.net",
+					Username: "test-user",
+					Password: "test-password-12345678",
+				},
+			},
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, eventlogstreaming.DestinationTypeGrafanaLoki, resp.EventLogStreamingConfig.DestinationType)
+		assert.Equal(t, "logs-prod-us-central1.grafana.net", resp.EventLogStreamingConfig.DestinationConfig.GrafanaLoki.Hostname)
+		assert.Equal(t, "test-user", resp.EventLogStreamingConfig.DestinationConfig.GrafanaLoki.Username)
+		assert.Equal(t, "test-password-12345678", resp.EventLogStreamingConfig.DestinationConfig.GrafanaLoki.Password)
+		assert.Equal(t, eventlogstreaming.StreamingStatusDisabled, resp.EventLogStreamingConfig.StreamingStatus)
+	})
+}
+
+func TestEventLogStreamingClient_Get(t *testing.T) {
+	t.Run("get datadog config", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Create config first
+		_, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+			DestinationConfig: eventlogstreaming.DestinationConfig{
+				Datadog: &eventlogstreaming.DatadogConfig{
+					Site:   eventlogstreaming.DatadogSiteUS,
+					APIKey: "1234567890abcdef1234567890abcdef",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.EventLogStreaming.Get(ctx, eventlogstreaming.GetEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, eventlogstreaming.DestinationTypeDatadog, resp.EventLogStreamingConfig.DestinationType)
+		assert.Equal(t, eventlogstreaming.DatadogSiteUS, resp.EventLogStreamingConfig.DestinationConfig.Datadog.Site)
+		assert.Equal(t, "cdef", resp.EventLogStreamingConfig.DestinationConfig.Datadog.APIKeyLastFour)
+		assert.Equal(t, eventlogstreaming.StreamingStatusDisabled, resp.EventLogStreamingConfig.StreamingStatus)
+	})
+
+	t.Run("config does not exist", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.EventLogStreaming.Get(ctx, eventlogstreaming.GetEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+		})
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestEventLogStreamingClient_Update(t *testing.T) {
+	t.Run("update datadog config", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Create config first
+		_, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+			DestinationConfig: eventlogstreaming.DestinationConfig{
+				Datadog: &eventlogstreaming.DatadogConfig{
+					Site:   eventlogstreaming.DatadogSiteUS,
+					APIKey: "1234567890abcdef1234567890abcdef",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.EventLogStreaming.Update(ctx, eventlogstreaming.UpdateEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+			DestinationConfig: eventlogstreaming.DestinationConfig{
+				Datadog: &eventlogstreaming.DatadogConfig{
+					Site:   eventlogstreaming.DatadogSiteEU,
+					APIKey: "abcdefabcdefabcdefabcdefabcdefab",
+				},
+			},
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, eventlogstreaming.DestinationTypeDatadog, resp.EventLogStreamingConfig.DestinationType)
+		assert.Equal(t, eventlogstreaming.DatadogSiteEU, resp.EventLogStreamingConfig.DestinationConfig.Datadog.Site)
+		assert.Equal(t, "abcdefabcdefabcdefabcdefabcdefab", resp.EventLogStreamingConfig.DestinationConfig.Datadog.APIKey)
+	})
+
+	t.Run("update grafana loki config", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Create Loki config first
+		_, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeGrafanaLoki,
+			DestinationConfig: eventlogstreaming.DestinationConfig{
+				GrafanaLoki: &eventlogstreaming.GrafanaLokiConfig{
+					Hostname: "logs-prod-us-central1.grafana.net",
+					Username: "initial-user",
+					Password: "initial-password-12345678",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.EventLogStreaming.Update(ctx, eventlogstreaming.UpdateEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeGrafanaLoki,
+			DestinationConfig: eventlogstreaming.DestinationConfig{
+				GrafanaLoki: &eventlogstreaming.GrafanaLokiConfig{
+					Hostname: "logs-prod-eu-west-0.grafana.net",
+					Username: "updated-user",
+					Password: "updated-password-87654321",
+				},
+			},
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, eventlogstreaming.DestinationTypeGrafanaLoki, resp.EventLogStreamingConfig.DestinationType)
+		assert.Equal(t, "logs-prod-eu-west-0.grafana.net", resp.EventLogStreamingConfig.DestinationConfig.GrafanaLoki.Hostname)
+		assert.Equal(t, "updated-user", resp.EventLogStreamingConfig.DestinationConfig.GrafanaLoki.Username)
+		assert.Equal(t, "updated-password-87654321", resp.EventLogStreamingConfig.DestinationConfig.GrafanaLoki.Password)
+	})
+
+	t.Run("update loki config when datadog config exists", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Create Datadog config first
+		_, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+			DestinationConfig: eventlogstreaming.DestinationConfig{
+				Datadog: &eventlogstreaming.DatadogConfig{
+					Site:   eventlogstreaming.DatadogSiteUS,
+					APIKey: "1234567890abcdef1234567890abcdef",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Act - Try to update with Loki config when Datadog exists
+		_, err = client.EventLogStreaming.Update(ctx, eventlogstreaming.UpdateEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeGrafanaLoki,
+			DestinationConfig: eventlogstreaming.DestinationConfig{
+				GrafanaLoki: &eventlogstreaming.GrafanaLokiConfig{
+					Hostname: "logs-prod-eu-west-0.grafana.net",
+					Username: "test-user",
+					Password: "test-password-12345678",
+				},
+			},
+		})
+
+		// Assert
+		assert.Error(t, err)
+	})
+
+	t.Run("config does not exist", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		_, err := client.EventLogStreaming.Update(ctx, eventlogstreaming.UpdateEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+			DestinationConfig: eventlogstreaming.DestinationConfig{
+				Datadog: &eventlogstreaming.DatadogConfig{
+					Site:   eventlogstreaming.DatadogSiteUS,
+					APIKey: "1234567890abcdef1234567890abcdef",
+				},
+			},
+		})
+
+		// Assert
+		assert.Error(t, err)
+	})
+}
+
+func TestEventLogStreamingClient_Enable(t *testing.T) {
+	t.Run("enable config", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Create config first
+		_, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+			DestinationConfig: eventlogstreaming.DestinationConfig{
+				Datadog: &eventlogstreaming.DatadogConfig{
+					Site:   eventlogstreaming.DatadogSiteUS,
+					APIKey: "1234567890abcdef1234567890abcdef",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.EventLogStreaming.Enable(ctx, eventlogstreaming.EnableEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotEmpty(t, resp.RequestID)
+	})
+
+	t.Run("config does not exist", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		_, err := client.EventLogStreaming.Enable(ctx, eventlogstreaming.EnableEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+		})
+
+		// Assert
+		assert.Error(t, err)
+	})
+}
+
+func TestEventLogStreamingClient_Disable(t *testing.T) {
+	t.Run("disable config", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Create and enable config first
+		_, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+			DestinationConfig: eventlogstreaming.DestinationConfig{
+				Datadog: &eventlogstreaming.DatadogConfig{
+					Site:   eventlogstreaming.DatadogSiteUS,
+					APIKey: "1234567890abcdef1234567890abcdef",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = client.EventLogStreaming.Enable(ctx, eventlogstreaming.EnableEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.EventLogStreaming.Disable(ctx, eventlogstreaming.DisableEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotEmpty(t, resp.RequestID)
+	})
+
+	t.Run("config does not exist", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		_, err := client.EventLogStreaming.Disable(ctx, eventlogstreaming.DisableEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+		})
+
+		// Assert
+		assert.Error(t, err)
+	})
+}
+
+func TestEventLogStreamingClient_Delete(t *testing.T) {
+	t.Run("delete config", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Create config first
+		_, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+			DestinationConfig: eventlogstreaming.DestinationConfig{
+				Datadog: &eventlogstreaming.DatadogConfig{
+					Site:   eventlogstreaming.DatadogSiteUS,
+					APIKey: "1234567890abcdef1234567890abcdef",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.EventLogStreaming.Delete(ctx, eventlogstreaming.DeleteEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotEmpty(t, resp.RequestID)
+
+		// Verify config is deleted by trying to get it
+		getResp, err := client.EventLogStreaming.Get(ctx, eventlogstreaming.GetEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+		})
+		assert.Error(t, err)
+		assert.Nil(t, getResp)
+	})
+
+	t.Run("config does not exist", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		_, err := client.EventLogStreaming.Delete(ctx, eventlogstreaming.DeleteEventLogStreamingRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			DestinationType: eventlogstreaming.DestinationTypeDatadog,
+		})
+
+		// Assert
+		assert.Error(t, err)
+	})
+}

--- a/pkg/api/eventlogstreaming_test.go
+++ b/pkg/api/eventlogstreaming_test.go
@@ -20,7 +20,7 @@ func TestEventLogStreamingClient_Create(t *testing.T) {
 		// Act
 		resp, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 			DestinationConfig: eventlogstreaming.DestinationConfig{
 				Datadog: &eventlogstreaming.DatadogConfig{
@@ -47,7 +47,7 @@ func TestEventLogStreamingClient_Create(t *testing.T) {
 		// Act
 		resp, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeGrafanaLoki,
 			DestinationConfig: eventlogstreaming.DestinationConfig{
 				GrafanaLoki: &eventlogstreaming.GrafanaLokiConfig{
@@ -78,7 +78,7 @@ func TestEventLogStreamingClient_Get(t *testing.T) {
 		// Create config first
 		_, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 			DestinationConfig: eventlogstreaming.DestinationConfig{
 				Datadog: &eventlogstreaming.DatadogConfig{
@@ -92,7 +92,7 @@ func TestEventLogStreamingClient_Get(t *testing.T) {
 		// Act
 		resp, err := client.EventLogStreaming.Get(ctx, eventlogstreaming.GetEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 		})
 
@@ -113,7 +113,7 @@ func TestEventLogStreamingClient_Get(t *testing.T) {
 		// Act
 		resp, err := client.EventLogStreaming.Get(ctx, eventlogstreaming.GetEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 		})
 
@@ -133,7 +133,7 @@ func TestEventLogStreamingClient_Update(t *testing.T) {
 		// Create config first
 		_, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 			DestinationConfig: eventlogstreaming.DestinationConfig{
 				Datadog: &eventlogstreaming.DatadogConfig{
@@ -147,7 +147,7 @@ func TestEventLogStreamingClient_Update(t *testing.T) {
 		// Act
 		resp, err := client.EventLogStreaming.Update(ctx, eventlogstreaming.UpdateEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 			DestinationConfig: eventlogstreaming.DestinationConfig{
 				Datadog: &eventlogstreaming.DatadogConfig{
@@ -173,7 +173,7 @@ func TestEventLogStreamingClient_Update(t *testing.T) {
 		// Create Loki config first
 		_, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeGrafanaLoki,
 			DestinationConfig: eventlogstreaming.DestinationConfig{
 				GrafanaLoki: &eventlogstreaming.GrafanaLokiConfig{
@@ -188,7 +188,7 @@ func TestEventLogStreamingClient_Update(t *testing.T) {
 		// Act
 		resp, err := client.EventLogStreaming.Update(ctx, eventlogstreaming.UpdateEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeGrafanaLoki,
 			DestinationConfig: eventlogstreaming.DestinationConfig{
 				GrafanaLoki: &eventlogstreaming.GrafanaLokiConfig{
@@ -216,7 +216,7 @@ func TestEventLogStreamingClient_Update(t *testing.T) {
 		// Create Datadog config first
 		_, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 			DestinationConfig: eventlogstreaming.DestinationConfig{
 				Datadog: &eventlogstreaming.DatadogConfig{
@@ -228,9 +228,9 @@ func TestEventLogStreamingClient_Update(t *testing.T) {
 		require.NoError(t, err)
 
 		// Act - Try to update with Loki config when Datadog exists
-		_, err = client.EventLogStreaming.Update(ctx, eventlogstreaming.UpdateEventLogStreamingRequest{
+		resp, err := client.EventLogStreaming.Update(ctx, eventlogstreaming.UpdateEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeGrafanaLoki,
 			DestinationConfig: eventlogstreaming.DestinationConfig{
 				GrafanaLoki: &eventlogstreaming.GrafanaLokiConfig{
@@ -243,6 +243,8 @@ func TestEventLogStreamingClient_Update(t *testing.T) {
 
 		// Assert
 		assert.Error(t, err)
+		assert.Nil(t, resp)
+
 	})
 
 	t.Run("config does not exist", func(t *testing.T) {
@@ -252,9 +254,9 @@ func TestEventLogStreamingClient_Update(t *testing.T) {
 		ctx := context.Background()
 
 		// Act
-		_, err := client.EventLogStreaming.Update(ctx, eventlogstreaming.UpdateEventLogStreamingRequest{
+		resp, err := client.EventLogStreaming.Update(ctx, eventlogstreaming.UpdateEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 			DestinationConfig: eventlogstreaming.DestinationConfig{
 				Datadog: &eventlogstreaming.DatadogConfig{
@@ -266,6 +268,7 @@ func TestEventLogStreamingClient_Update(t *testing.T) {
 
 		// Assert
 		assert.Error(t, err)
+		assert.Nil(t, resp)
 	})
 }
 
@@ -279,7 +282,7 @@ func TestEventLogStreamingClient_Enable(t *testing.T) {
 		// Create config first
 		_, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 			DestinationConfig: eventlogstreaming.DestinationConfig{
 				Datadog: &eventlogstreaming.DatadogConfig{
@@ -293,7 +296,7 @@ func TestEventLogStreamingClient_Enable(t *testing.T) {
 		// Act
 		resp, err := client.EventLogStreaming.Enable(ctx, eventlogstreaming.EnableEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 		})
 
@@ -309,14 +312,15 @@ func TestEventLogStreamingClient_Enable(t *testing.T) {
 		ctx := context.Background()
 
 		// Act
-		_, err := client.EventLogStreaming.Enable(ctx, eventlogstreaming.EnableEventLogStreamingRequest{
+		resp, err := client.EventLogStreaming.Enable(ctx, eventlogstreaming.EnableEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 		})
 
 		// Assert
 		assert.Error(t, err)
+		assert.Nil(t, resp)
 	})
 }
 
@@ -330,7 +334,7 @@ func TestEventLogStreamingClient_Disable(t *testing.T) {
 		// Create and enable config first
 		_, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 			DestinationConfig: eventlogstreaming.DestinationConfig{
 				Datadog: &eventlogstreaming.DatadogConfig{
@@ -343,7 +347,7 @@ func TestEventLogStreamingClient_Disable(t *testing.T) {
 
 		_, err = client.EventLogStreaming.Enable(ctx, eventlogstreaming.EnableEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 		})
 		require.NoError(t, err)
@@ -351,7 +355,7 @@ func TestEventLogStreamingClient_Disable(t *testing.T) {
 		// Act
 		resp, err := client.EventLogStreaming.Disable(ctx, eventlogstreaming.DisableEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 		})
 
@@ -367,14 +371,15 @@ func TestEventLogStreamingClient_Disable(t *testing.T) {
 		ctx := context.Background()
 
 		// Act
-		_, err := client.EventLogStreaming.Disable(ctx, eventlogstreaming.DisableEventLogStreamingRequest{
+		resp, err := client.EventLogStreaming.Disable(ctx, eventlogstreaming.DisableEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 		})
 
 		// Assert
 		assert.Error(t, err)
+		assert.Nil(t, resp)
 	})
 }
 
@@ -388,7 +393,7 @@ func TestEventLogStreamingClient_Delete(t *testing.T) {
 		// Create config first
 		_, err := client.EventLogStreaming.Create(ctx, eventlogstreaming.CreateEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 			DestinationConfig: eventlogstreaming.DestinationConfig{
 				Datadog: &eventlogstreaming.DatadogConfig{
@@ -402,7 +407,7 @@ func TestEventLogStreamingClient_Delete(t *testing.T) {
 		// Act
 		resp, err := client.EventLogStreaming.Delete(ctx, eventlogstreaming.DeleteEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 		})
 
@@ -413,7 +418,7 @@ func TestEventLogStreamingClient_Delete(t *testing.T) {
 		// Verify config is deleted by trying to get it
 		getResp, err := client.EventLogStreaming.Get(ctx, eventlogstreaming.GetEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 		})
 		assert.Error(t, err)
@@ -427,13 +432,14 @@ func TestEventLogStreamingClient_Delete(t *testing.T) {
 		ctx := context.Background()
 
 		// Act
-		_, err := client.EventLogStreaming.Delete(ctx, eventlogstreaming.DeleteEventLogStreamingRequest{
+		resp, err := client.EventLogStreaming.Delete(ctx, eventlogstreaming.DeleteEventLogStreamingRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			DestinationType: eventlogstreaming.DestinationTypeDatadog,
 		})
 
 		// Assert
 		assert.Error(t, err)
+		assert.Nil(t, resp)
 	})
 }

--- a/pkg/api/jwttemplates.go
+++ b/pkg/api/jwttemplates.go
@@ -31,7 +31,10 @@ func (c *JWTTemplatesClient) Get(
 		nil,
 		&resp)
 
-	return &resp, err
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }
 
 // Set updates a specific JWT template for a project
@@ -48,9 +51,12 @@ func (c *JWTTemplatesClient) Set(
 	err = c.client.NewRequest(
 		ctx,
 		"PUT",
-		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/jwt_templates/%s", body.Project, body.Environment, body.JWTTemplate.TemplateType),
+		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/jwt_templates/%s", body.Project, body.Environment, body.TemplateType),
 		nil,
 		jsonBody,
 		&res)
-	return &res, err
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
 }

--- a/pkg/api/jwttemplates_test.go
+++ b/pkg/api/jwttemplates_test.go
@@ -22,7 +22,7 @@ func TestJWTTemplatesClient_GetJWTTemplate(t *testing.T) {
 		// First set a template
 		_, err := client.JWTTemplates.Set(ctx, &jwttemplates.SetRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			TemplateType:    jwttemplates.TemplateTypeSession,
 			TemplateContent: templateContent,
 			CustomAudience:  customAudience,
@@ -32,7 +32,7 @@ func TestJWTTemplatesClient_GetJWTTemplate(t *testing.T) {
 		// Act
 		resp, err := client.JWTTemplates.Get(ctx, &jwttemplates.GetRequest{
 			Project:      project.Project,
-			Environment:  "test",
+			Environment:  TestEnvironment,
 			TemplateType: jwttemplates.TemplateTypeSession,
 		})
 
@@ -54,7 +54,7 @@ func TestJWTTemplatesClient_GetJWTTemplate(t *testing.T) {
 		// First set a template
 		_, err := client.JWTTemplates.Set(ctx, &jwttemplates.SetRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			TemplateType:    jwttemplates.TemplateTypeM2M,
 			TemplateContent: templateContent,
 			CustomAudience:  customAudience,
@@ -64,7 +64,7 @@ func TestJWTTemplatesClient_GetJWTTemplate(t *testing.T) {
 		// Act
 		resp, err := client.JWTTemplates.Get(ctx, &jwttemplates.GetRequest{
 			Project:      project.Project,
-			Environment:  "test",
+			Environment:  TestEnvironment,
 			TemplateType: jwttemplates.TemplateTypeM2M,
 		})
 
@@ -88,7 +88,7 @@ func TestJWTTemplatesClient_SetJWTTemplate(t *testing.T) {
 		// Act
 		setResp, err := client.JWTTemplates.Set(ctx, &jwttemplates.SetRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			TemplateType:    jwttemplates.TemplateTypeSession,
 			TemplateContent: templateContent,
 			CustomAudience:  customAudience,
@@ -112,7 +112,7 @@ func TestJWTTemplatesClient_SetJWTTemplate(t *testing.T) {
 		// Act
 		setResp, err := client.JWTTemplates.Set(ctx, &jwttemplates.SetRequest{
 			Project:         project.Project,
-			Environment:     "test",
+			Environment:     TestEnvironment,
 			TemplateType:    jwttemplates.TemplateTypeM2M,
 			TemplateContent: templateContent,
 			CustomAudience:  customAudience,

--- a/pkg/api/jwttemplates_test.go
+++ b/pkg/api/jwttemplates_test.go
@@ -1,0 +1,127 @@
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/jwttemplates"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/projects"
+)
+
+func TestJWTTemplatesClient_GetJWTTemplate(t *testing.T) {
+	t.Run("get session template", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+		templateContent := `{"custom_user_id": "user-123", "custom_email": "test@example.com"}`
+		customAudience := "my-custom-audience"
+
+		// First set a template
+		_, err := client.JWTTemplates.Set(ctx, &jwttemplates.SetRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			TemplateType:    jwttemplates.TemplateTypeSession,
+			TemplateContent: templateContent,
+			CustomAudience:  customAudience,
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.JWTTemplates.Get(ctx, &jwttemplates.GetRequest{
+			Project:      project.Project,
+			Environment:  "test",
+			TemplateType: jwttemplates.TemplateTypeSession,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, templateContent, resp.JWTTemplate.TemplateContent)
+		assert.Equal(t, customAudience, resp.JWTTemplate.CustomAudience)
+		assert.Equal(t, jwttemplates.TemplateTypeSession, resp.JWTTemplate.TemplateType)
+	})
+
+	t.Run("get m2m template", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+		templateContent := `{"custom_org_id": "org-456", "custom_name": "Test Organization"}`
+		customAudience := "m2m-audience"
+
+		// First set a template
+		_, err := client.JWTTemplates.Set(ctx, &jwttemplates.SetRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			TemplateType:    jwttemplates.TemplateTypeM2M,
+			TemplateContent: templateContent,
+			CustomAudience:  customAudience,
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.JWTTemplates.Get(ctx, &jwttemplates.GetRequest{
+			Project:      project.Project,
+			Environment:  "test",
+			TemplateType: jwttemplates.TemplateTypeM2M,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, templateContent, resp.JWTTemplate.TemplateContent)
+		assert.Equal(t, customAudience, resp.JWTTemplate.CustomAudience)
+		assert.Equal(t, jwttemplates.TemplateTypeM2M, resp.JWTTemplate.TemplateType)
+	})
+}
+
+func TestJWTTemplatesClient_SetJWTTemplate(t *testing.T) {
+	t.Run("set session template", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+		templateContent := `{"custom_user_id": "user-123", "custom_email": "test@example.com"}`
+		customAudience := "my-custom-audience"
+
+		// Act
+		setResp, err := client.JWTTemplates.Set(ctx, &jwttemplates.SetRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			TemplateType:    jwttemplates.TemplateTypeSession,
+			TemplateContent: templateContent,
+			CustomAudience:  customAudience,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, templateContent, setResp.JWTTemplate.TemplateContent)
+		assert.Equal(t, customAudience, setResp.JWTTemplate.CustomAudience)
+		assert.Equal(t, jwttemplates.TemplateTypeSession, setResp.JWTTemplate.TemplateType)
+	})
+
+	t.Run("set m2m template", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+		templateContent := `{"custom_org_id": "org-456", "custom_name": "Test Organization"}`
+		customAudience := "m2m-audience"
+
+		// Act
+		setResp, err := client.JWTTemplates.Set(ctx, &jwttemplates.SetRequest{
+			Project:         project.Project,
+			Environment:     "test",
+			TemplateType:    jwttemplates.TemplateTypeM2M,
+			TemplateContent: templateContent,
+			CustomAudience:  customAudience,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, templateContent, setResp.JWTTemplate.TemplateContent)
+		assert.Equal(t, customAudience, setResp.JWTTemplate.CustomAudience)
+		assert.Equal(t, jwttemplates.TemplateTypeM2M, setResp.JWTTemplate.TemplateType)
+	})
+}

--- a/pkg/api/publictokens.go
+++ b/pkg/api/publictokens.go
@@ -28,7 +28,10 @@ func (c *PublicTokensClient) GetAll(ctx context.Context, body publictokens.GetAl
 		nil,
 		&resp)
 
-	return &resp, err
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }
 
 // Create creates a new public token for a project.
@@ -46,7 +49,10 @@ func (c *PublicTokensClient) Create(ctx context.Context, body publictokens.Creat
 		nil,
 		jsonBody,
 		&res)
-	return &res, err
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
 }
 
 // Delete deletes a public token for a project.
@@ -59,5 +65,8 @@ func (c *PublicTokensClient) Delete(ctx context.Context, body publictokens.Delet
 		nil,
 		nil,
 		&res)
-	return &res, err
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
 }

--- a/pkg/api/publictokens_test.go
+++ b/pkg/api/publictokens_test.go
@@ -1,0 +1,130 @@
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/publictokens"
+)
+
+func TestPublicTokensClient_Create(t *testing.T) {
+	t.Run("create public token", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.PublicTokens.Create(ctx, publictokens.CreateRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotEmpty(t, resp.PublicToken.PublicToken)
+		assert.True(t, len(resp.PublicToken.PublicToken) > 10)
+		assert.False(t, resp.PublicToken.CreatedAt.IsZero())
+	})
+}
+
+func TestPublicTokensClient_GetAll(t *testing.T) {
+	t.Run("get all public tokens", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Create a few public tokens first
+		var createdTokens []publictokens.PublicToken
+		for i := 0; i < 3; i++ {
+			createResp, err := client.PublicTokens.Create(ctx, publictokens.CreateRequest{
+				Project:     project.Project,
+				Environment: TestEnvironment,
+			})
+			require.NoError(t, err)
+			createdTokens = append(createdTokens, createResp.PublicToken)
+		}
+
+		// Act
+		resp, err := client.PublicTokens.GetAll(ctx, publictokens.GetAllRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, len(resp.PublicTokens), 3)
+
+		// Verify all created tokens are returned
+		tokenValues := make(map[string]bool)
+		for _, token := range resp.PublicTokens {
+			tokenValues[token.PublicToken] = true
+			assert.NotEmpty(t, token.PublicToken)
+			assert.False(t, token.CreatedAt.IsZero())
+		}
+
+		for _, createdToken := range createdTokens {
+			assert.True(t, tokenValues[createdToken.PublicToken], "Created token %s not found in response", createdToken.PublicToken)
+		}
+	})
+}
+
+func TestPublicTokensClient_Delete(t *testing.T) {
+	t.Run("delete existing public token", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Create a public token first
+		createResp, err := client.PublicTokens.Create(ctx, publictokens.CreateRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.PublicTokens.Delete(ctx, publictokens.DeleteRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			PublicToken: createResp.PublicToken.PublicToken,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotEmpty(t, resp.RequestID)
+
+		// Verify token is deleted by checking GetAll doesn't include it
+		getAllResp, err := client.PublicTokens.GetAll(ctx, publictokens.GetAllRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+		})
+		require.NoError(t, err)
+
+		for _, token := range getAllResp.PublicTokens {
+			assert.NotEqual(t, createResp.PublicToken.PublicToken, token.PublicToken, "Deleted token should not appear in GetAll response")
+		}
+	})
+
+	t.Run("public token does not exist", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.PublicTokens.Delete(ctx, publictokens.DeleteRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			PublicToken: "public-token-does-not-exist",
+		})
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}

--- a/pkg/api/secrets.go
+++ b/pkg/api/secrets.go
@@ -26,7 +26,10 @@ func (c *SecretsClient) Get(ctx context.Context, body secrets.GetSecretRequest) 
 		nil,
 		&resp,
 	)
-	return &resp, err
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }
 
 // GetAll retrieves all secrets for a project
@@ -40,7 +43,10 @@ func (c *SecretsClient) GetAll(ctx context.Context, body secrets.GetAllSecretsRe
 		nil,
 		&resp,
 	)
-	return &resp, err
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }
 
 // Create creates a secret for a project. The response has the secret value, which
@@ -55,7 +61,10 @@ func (c *SecretsClient) Create(ctx context.Context, body secrets.CreateSecretReq
 		nil,
 		&resp,
 	)
-	return &resp, err
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }
 
 // Delete deletes a secret for a project
@@ -69,5 +78,8 @@ func (c *SecretsClient) Delete(ctx context.Context, body secrets.DeleteSecretReq
 		nil,
 		&resp,
 	)
-	return &resp, err
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }

--- a/pkg/api/secrets_test.go
+++ b/pkg/api/secrets_test.go
@@ -20,7 +20,7 @@ func TestSecretsClient_CreateSecret(t *testing.T) {
 		// Act
 		resp, err := client.Secrets.Create(ctx, secrets.CreateSecretRequest{
 			Project:     project.Project,
-			Environment: "test",
+			Environment: TestEnvironment,
 		})
 
 		// Assert
@@ -42,14 +42,14 @@ func TestSecretsClient_GetSecret(t *testing.T) {
 		// Create a secret first
 		createResp, err := client.Secrets.Create(ctx, secrets.CreateSecretRequest{
 			Project:     project.Project,
-			Environment: "test",
+			Environment: TestEnvironment,
 		})
 		require.NoError(t, err)
 
 		// Act
 		resp, err := client.Secrets.Get(ctx, secrets.GetSecretRequest{
 			Project:     project.Project,
-			Environment: "test",
+			Environment: TestEnvironment,
 			SecretID:    createResp.CreatedSecret.SecretID,
 		})
 
@@ -71,7 +71,7 @@ func TestSecretsClient_GetSecret(t *testing.T) {
 		// Act
 		resp, err := client.Secrets.Get(ctx, secrets.GetSecretRequest{
 			Project:     project.Project,
-			Environment: "test",
+			Environment: TestEnvironment,
 			SecretID:    "secret-does-not-exist",
 		})
 
@@ -93,7 +93,7 @@ func TestSecretsClient_GetAllSecrets(t *testing.T) {
 		for i := 0; i < 3; i++ {
 			createResp, err := client.Secrets.Create(ctx, secrets.CreateSecretRequest{
 				Project:     project.Project,
-				Environment: "test",
+				Environment: TestEnvironment,
 			})
 			require.NoError(t, err)
 			createdSecrets = append(createdSecrets, createResp.CreatedSecret)
@@ -102,7 +102,7 @@ func TestSecretsClient_GetAllSecrets(t *testing.T) {
 		// Act
 		resp, err := client.Secrets.GetAll(ctx, secrets.GetAllSecretsRequest{
 			Project:     project.Project,
-			Environment: "test",
+			Environment: TestEnvironment,
 		})
 
 		// Assert
@@ -131,7 +131,7 @@ func TestSecretsClient_GetAllSecrets(t *testing.T) {
 		// Act
 		resp, err := client.Secrets.GetAll(ctx, secrets.GetAllSecretsRequest{
 			Project:     project.Project,
-			Environment: "test",
+			Environment: TestEnvironment,
 		})
 
 		// Assert
@@ -150,14 +150,14 @@ func TestSecretsClient_DeleteSecret(t *testing.T) {
 		// Create a secret first
 		createResp, err := client.Secrets.Create(ctx, secrets.CreateSecretRequest{
 			Project:     project.Project,
-			Environment: "test",
+			Environment: TestEnvironment,
 		})
 		require.NoError(t, err)
 
 		// Act
 		resp, err := client.Secrets.Delete(ctx, secrets.DeleteSecretRequest{
 			Project:     project.Project,
-			Environment: "test",
+			Environment: TestEnvironment,
 			SecretID:    createResp.CreatedSecret.SecretID,
 		})
 
@@ -168,7 +168,7 @@ func TestSecretsClient_DeleteSecret(t *testing.T) {
 		// Verify secret is deleted by trying to get it
 		getResp, err := client.Secrets.Get(ctx, secrets.GetSecretRequest{
 			Project:     project.Project,
-			Environment: "test",
+			Environment: TestEnvironment,
 			SecretID:    createResp.CreatedSecret.SecretID,
 		})
 		assert.Error(t, err)
@@ -184,7 +184,7 @@ func TestSecretsClient_DeleteSecret(t *testing.T) {
 		// Act
 		_, err := client.Secrets.Delete(ctx, secrets.DeleteSecretRequest{
 			Project:     project.Project,
-			Environment: "test",
+			Environment: TestEnvironment,
 			SecretID:    "secret-does-not-exist",
 		})
 

--- a/pkg/api/secrets_test.go
+++ b/pkg/api/secrets_test.go
@@ -1,0 +1,194 @@
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/secrets"
+)
+
+func TestSecretsClient_CreateSecret(t *testing.T) {
+	t.Run("create secret", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.Secrets.Create(ctx, secrets.CreateSecretRequest{
+			Project:     project.Project,
+			Environment: "test",
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotEmpty(t, resp.CreatedSecret.SecretID)
+		assert.NotEmpty(t, resp.CreatedSecret.Secret)
+		assert.True(t, len(resp.CreatedSecret.Secret) > 10)
+		assert.False(t, resp.CreatedSecret.CreatedAt.IsZero())
+	})
+}
+
+func TestSecretsClient_GetSecret(t *testing.T) {
+	t.Run("get existing secret", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Create a secret first
+		createResp, err := client.Secrets.Create(ctx, secrets.CreateSecretRequest{
+			Project:     project.Project,
+			Environment: "test",
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.Secrets.Get(ctx, secrets.GetSecretRequest{
+			Project:     project.Project,
+			Environment: "test",
+			SecretID:    createResp.CreatedSecret.SecretID,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, createResp.CreatedSecret.SecretID, resp.Secret.SecretID)
+		assert.NotEmpty(t, resp.Secret.LastFour)
+		assert.False(t, resp.Secret.CreatedAt.IsZero())
+		assert.Equal(t, createResp.CreatedSecret.Secret[len(createResp.CreatedSecret.Secret)-4:], resp.Secret.LastFour)
+		assert.Equal(t, createResp.CreatedSecret.CreatedAt, resp.Secret.CreatedAt)
+	})
+
+	t.Run("secret does not exist", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.Secrets.Get(ctx, secrets.GetSecretRequest{
+			Project:     project.Project,
+			Environment: "test",
+			SecretID:    "secret-does-not-exist",
+		})
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestSecretsClient_GetAllSecrets(t *testing.T) {
+	t.Run("get all secrets", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Create a few secrets first
+		var createdSecrets []secrets.CreatedSecret
+		for i := 0; i < 3; i++ {
+			createResp, err := client.Secrets.Create(ctx, secrets.CreateSecretRequest{
+				Project:     project.Project,
+				Environment: "test",
+			})
+			require.NoError(t, err)
+			createdSecrets = append(createdSecrets, createResp.CreatedSecret)
+		}
+
+		// Act
+		resp, err := client.Secrets.GetAll(ctx, secrets.GetAllSecretsRequest{
+			Project:     project.Project,
+			Environment: "test",
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, len(resp.Secrets), 3)
+
+		// Verify all created secrets are returned
+		secretIDs := make(map[string]bool)
+		for _, secret := range resp.Secrets {
+			secretIDs[secret.SecretID] = true
+			assert.NotEmpty(t, secret.LastFour)
+			assert.False(t, secret.CreatedAt.IsZero())
+		}
+
+		for _, createdSecret := range createdSecrets {
+			assert.True(t, secretIDs[createdSecret.SecretID], "Created secret %s not found in response", createdSecret.SecretID)
+		}
+	})
+
+	t.Run("only the default secret exists", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.Secrets.GetAll(ctx, secrets.GetAllSecretsRequest{
+			Project:     project.Project,
+			Environment: "test",
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Len(t, resp.Secrets, 1)
+	})
+}
+
+func TestSecretsClient_DeleteSecret(t *testing.T) {
+	t.Run("delete existing secret", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Create a secret first
+		createResp, err := client.Secrets.Create(ctx, secrets.CreateSecretRequest{
+			Project:     project.Project,
+			Environment: "test",
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.Secrets.Delete(ctx, secrets.DeleteSecretRequest{
+			Project:     project.Project,
+			Environment: "test",
+			SecretID:    createResp.CreatedSecret.SecretID,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotEmpty(t, resp.RequestID)
+
+		// Verify secret is deleted by trying to get it
+		getResp, err := client.Secrets.Get(ctx, secrets.GetSecretRequest{
+			Project:     project.Project,
+			Environment: "test",
+			SecretID:    createResp.CreatedSecret.SecretID,
+		})
+		assert.Error(t, err)
+		assert.Nil(t, getResp)
+	})
+
+	t.Run("secret does not exist", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		_, err := client.Secrets.Delete(ctx, secrets.DeleteSecretRequest{
+			Project:     project.Project,
+			Environment: "test",
+			SecretID:    "secret-does-not-exist",
+		})
+
+		// Assert
+		assert.Error(t, err)
+	})
+}

--- a/pkg/models/jwttemplates/types.go
+++ b/pkg/models/jwttemplates/types.go
@@ -47,9 +47,13 @@ type SetRequest struct {
 	// Project is the project for which to set the JWT template
 	Project string `json:"-"`
 	// Environment is the environment for which to set the JWT template
-	Environment string `json:"environment"`
-	// JWTTemplate is the JWT template to set
-	JWTTemplate JWTTemplate `json:"jwt_template"`
+	Environment string `json:"-"`
+	// TemplateType is the type of JWT template
+	TemplateType TemplateType `json:"template_type"`
+	// TemplateContent is the JWT template content
+	TemplateContent string `json:"template_content"`
+	// CustomAudience is an optional custom audience for the JWT template
+	CustomAudience string `json:"custom_audience"`
 }
 
 type SetResponse struct {

--- a/pkg/models/secrets/types.go
+++ b/pkg/models/secrets/types.go
@@ -71,7 +71,7 @@ type CreateSecretResponse struct {
 	// RequestID is a unique identifier to help with debugging the request
 	RequestID string `json:"request_id"`
 	// CreatedSecret is the newly created secret. The value of this secret is only visible in this response.
-	CreatedSecret CreatedSecret `json:"created_secret"`
+	CreatedSecret CreatedSecret `json:"secret"`
 }
 
 type DeleteSecretRequest struct {


### PR DESCRIPTION
## Description 

Fixed a few services:
- JWT Templates: Add proper error handling and make sure schema is not nested
- Secrets: Add proper error handling, and make sure created secret marshals to `"secret"` in json
- Public tokens: Add proper error handling

Tests for many services. 

- JWT templates
- Secrets
- Event log streaming
- Public tokens

## Tests

`make test`

```
bpeynetti@Brunos-MacBook-Pro  ~/stytch/stytch-management-go   bpeynetti/tests ±  make test
=== RUN   TestCountryCodeAllowlistClient_GetAllowedSMSCountryCodes
=== RUN   TestCountryCodeAllowlistClient_GetAllowedSMSCountryCodes/default_country_codes
=== RUN   TestCountryCodeAllowlistClient_GetAllowedSMSCountryCodes/get_country_codes
=== RUN   TestCountryCodeAllowlistClient_GetAllowedSMSCountryCodes/project_does_not_exist
--- PASS: TestCountryCodeAllowlistClient_GetAllowedSMSCountryCodes (1.76s)
    --- PASS: TestCountryCodeAllowlistClient_GetAllowedSMSCountryCodes/default_country_codes (0.99s)
    --- PASS: TestCountryCodeAllowlistClient_GetAllowedSMSCountryCodes/get_country_codes (0.66s)
    --- PASS: TestCountryCodeAllowlistClient_GetAllowedSMSCountryCodes/project_does_not_exist (0.11s)
=== RUN   TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes
=== RUN   TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes/default_country_codes
=== RUN   TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes/get_country_codes
=== RUN   TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes/B2B_WhatsApp_not_supported
=== RUN   TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes/project_does_not_exist
--- PASS: TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes (1.86s)
    --- PASS: TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes/default_country_codes (0.52s)
    --- PASS: TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes/get_country_codes (0.67s)
    --- PASS: TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes/B2B_WhatsApp_not_supported (0.55s)
    --- PASS: TestCountryCodeAllowlistClient_GetAllowedWhatsAppCountryCodes/project_does_not_exist (0.12s)
=== RUN   TestCountryCodeAllowlistClient_SetAllowedSMSCountryCodes
=== RUN   TestCountryCodeAllowlistClient_SetAllowedSMSCountryCodes/set_country_codes
=== RUN   TestCountryCodeAllowlistClient_SetAllowedSMSCountryCodes/project_does_not_exist
--- PASS: TestCountryCodeAllowlistClient_SetAllowedSMSCountryCodes (0.78s)
    --- PASS: TestCountryCodeAllowlistClient_SetAllowedSMSCountryCodes/set_country_codes (0.68s)
    --- PASS: TestCountryCodeAllowlistClient_SetAllowedSMSCountryCodes/project_does_not_exist (0.10s)
=== RUN   TestCountryCodeAllowlistClient_SetAllowedWhatsAppCountryCodes
=== RUN   TestCountryCodeAllowlistClient_SetAllowedWhatsAppCountryCodes/set_country_codes
=== RUN   TestCountryCodeAllowlistClient_SetAllowedWhatsAppCountryCodes/B2B_WhatsApp_not_supported
=== RUN   TestCountryCodeAllowlistClient_SetAllowedWhatsAppCountryCodes/project_does_not_exist
--- PASS: TestCountryCodeAllowlistClient_SetAllowedWhatsAppCountryCodes (1.33s)
    --- PASS: TestCountryCodeAllowlistClient_SetAllowedWhatsAppCountryCodes/set_country_codes (0.67s)
    --- PASS: TestCountryCodeAllowlistClient_SetAllowedWhatsAppCountryCodes/B2B_WhatsApp_not_supported (0.55s)
    --- PASS: TestCountryCodeAllowlistClient_SetAllowedWhatsAppCountryCodes/project_does_not_exist (0.11s)
=== RUN   TestEventLogStreamingClient_Create
=== RUN   TestEventLogStreamingClient_Create/create_datadog_config
=== RUN   TestEventLogStreamingClient_Create/create_grafana_loki_config
--- PASS: TestEventLogStreamingClient_Create (1.11s)
    --- PASS: TestEventLogStreamingClient_Create/create_datadog_config (0.56s)
    --- PASS: TestEventLogStreamingClient_Create/create_grafana_loki_config (0.55s)
=== RUN   TestEventLogStreamingClient_Get
=== RUN   TestEventLogStreamingClient_Get/get_datadog_config
=== RUN   TestEventLogStreamingClient_Get/config_does_not_exist
--- PASS: TestEventLogStreamingClient_Get (1.22s)
    --- PASS: TestEventLogStreamingClient_Get/get_datadog_config (0.68s)
    --- PASS: TestEventLogStreamingClient_Get/config_does_not_exist (0.54s)
=== RUN   TestEventLogStreamingClient_Update
=== RUN   TestEventLogStreamingClient_Update/update_datadog_config
=== RUN   TestEventLogStreamingClient_Update/update_grafana_loki_config
=== RUN   TestEventLogStreamingClient_Update/update_loki_config_when_datadog_config_exists
=== RUN   TestEventLogStreamingClient_Update/config_does_not_exist
--- PASS: TestEventLogStreamingClient_Update (2.61s)
    --- PASS: TestEventLogStreamingClient_Update/update_datadog_config (0.70s)
    --- PASS: TestEventLogStreamingClient_Update/update_grafana_loki_config (0.69s)
    --- PASS: TestEventLogStreamingClient_Update/update_loki_config_when_datadog_config_exists (0.67s)
    --- PASS: TestEventLogStreamingClient_Update/config_does_not_exist (0.55s)
=== RUN   TestEventLogStreamingClient_Enable
=== RUN   TestEventLogStreamingClient_Enable/enable_config
=== RUN   TestEventLogStreamingClient_Enable/config_does_not_exist
--- PASS: TestEventLogStreamingClient_Enable (1.24s)
    --- PASS: TestEventLogStreamingClient_Enable/enable_config (0.69s)
    --- PASS: TestEventLogStreamingClient_Enable/config_does_not_exist (0.55s)
=== RUN   TestEventLogStreamingClient_Disable
=== RUN   TestEventLogStreamingClient_Disable/disable_config
=== RUN   TestEventLogStreamingClient_Disable/config_does_not_exist
--- PASS: TestEventLogStreamingClient_Disable (1.36s)
    --- PASS: TestEventLogStreamingClient_Disable/disable_config (0.82s)
    --- PASS: TestEventLogStreamingClient_Disable/config_does_not_exist (0.55s)
=== RUN   TestEventLogStreamingClient_Delete
=== RUN   TestEventLogStreamingClient_Delete/delete_config
=== RUN   TestEventLogStreamingClient_Delete/config_does_not_exist
--- PASS: TestEventLogStreamingClient_Delete (1.35s)
    --- PASS: TestEventLogStreamingClient_Delete/delete_config (0.81s)
    --- PASS: TestEventLogStreamingClient_Delete/config_does_not_exist (0.54s)
=== RUN   TestJWTTemplatesClient_GetJWTTemplate
=== RUN   TestJWTTemplatesClient_GetJWTTemplate/get_session_template
=== RUN   TestJWTTemplatesClient_GetJWTTemplate/get_m2m_template
--- PASS: TestJWTTemplatesClient_GetJWTTemplate (1.35s)
    --- PASS: TestJWTTemplatesClient_GetJWTTemplate/get_session_template (0.67s)
    --- PASS: TestJWTTemplatesClient_GetJWTTemplate/get_m2m_template (0.68s)
=== RUN   TestJWTTemplatesClient_SetJWTTemplate
=== RUN   TestJWTTemplatesClient_SetJWTTemplate/set_session_template
=== RUN   TestJWTTemplatesClient_SetJWTTemplate/set_m2m_template
--- PASS: TestJWTTemplatesClient_SetJWTTemplate (1.13s)
    --- PASS: TestJWTTemplatesClient_SetJWTTemplate/set_session_template (0.56s)
    --- PASS: TestJWTTemplatesClient_SetJWTTemplate/set_m2m_template (0.57s)
=== RUN   TestPublicTokensClient_Create
=== RUN   TestPublicTokensClient_Create/create_public_token
--- PASS: TestPublicTokensClient_Create (0.55s)
    --- PASS: TestPublicTokensClient_Create/create_public_token (0.55s)
=== RUN   TestPublicTokensClient_GetAll
=== RUN   TestPublicTokensClient_GetAll/get_all_public_tokens
--- PASS: TestPublicTokensClient_GetAll (0.92s)
    --- PASS: TestPublicTokensClient_GetAll/get_all_public_tokens (0.92s)
=== RUN   TestPublicTokensClient_Delete
=== RUN   TestPublicTokensClient_Delete/delete_existing_public_token
=== RUN   TestPublicTokensClient_Delete/public_token_does_not_exist
--- PASS: TestPublicTokensClient_Delete (1.35s)
    --- PASS: TestPublicTokensClient_Delete/delete_existing_public_token (0.80s)
    --- PASS: TestPublicTokensClient_Delete/public_token_does_not_exist (0.54s)
=== RUN   TestSecretsClient_CreateSecret
=== RUN   TestSecretsClient_CreateSecret/create_secret
--- PASS: TestSecretsClient_CreateSecret (0.58s)
    --- PASS: TestSecretsClient_CreateSecret/create_secret (0.58s)
=== RUN   TestSecretsClient_GetSecret
=== RUN   TestSecretsClient_GetSecret/get_existing_secret
=== RUN   TestSecretsClient_GetSecret/secret_does_not_exist
--- PASS: TestSecretsClient_GetSecret (1.24s)
    --- PASS: TestSecretsClient_GetSecret/get_existing_secret (0.68s)
    --- PASS: TestSecretsClient_GetSecret/secret_does_not_exist (0.56s)
=== RUN   TestSecretsClient_GetAllSecrets
=== RUN   TestSecretsClient_GetAllSecrets/get_all_secrets
=== RUN   TestSecretsClient_GetAllSecrets/only_the_default_secret_exists
--- PASS: TestSecretsClient_GetAllSecrets (1.50s)
    --- PASS: TestSecretsClient_GetAllSecrets/get_all_secrets (0.93s)
    --- PASS: TestSecretsClient_GetAllSecrets/only_the_default_secret_exists (0.56s)
=== RUN   TestSecretsClient_DeleteSecret
=== RUN   TestSecretsClient_DeleteSecret/delete_existing_secret
=== RUN   TestSecretsClient_DeleteSecret/secret_does_not_exist
--- PASS: TestSecretsClient_DeleteSecret (1.36s)
    --- PASS: TestSecretsClient_DeleteSecret/delete_existing_secret (0.81s)
    --- PASS: TestSecretsClient_DeleteSecret/secret_does_not_exist (0.55s)
PASS
ok      github.com/stytchauth/stytch-management-go/v3/pkg/api   25.113s
```