### PR TITLE
[V3] Tests for Redirect URL, Trusted Token Profiles, and PEM files

### DIFF
--- a/pkg/api/redirecturls.go
+++ b/pkg/api/redirecturls.go
@@ -35,7 +35,10 @@ func (c *RedirectURLsClient) Create(
 		nil,
 		jsonBody,
 		&res)
-	return &res, err
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
 }
 
 // GetAll retrieves all redirect URLs for a project environment
@@ -47,12 +50,15 @@ func (c *RedirectURLsClient) GetAll(
 	err := c.client.NewRequest(
 		ctx,
 		"GET",
-		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/redirect_urls", body.Project, body.Environment),
+		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/redirect_urls/all", body.Project, body.Environment),
 		nil,
 		nil,
 		&resp)
 
-	return &resp, err
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }
 
 // Get retrieves a redirect URL for a project environment
@@ -68,7 +74,10 @@ func (c *RedirectURLsClient) Get(
 		nil,
 		nil,
 		&res)
-	return &res, err
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
 }
 
 // Update updates the valid types for a redirect URL for a project environment
@@ -89,7 +98,10 @@ func (c *RedirectURLsClient) Update(
 		nil,
 		jsonBody,
 		&res)
-	return &res, err
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
 }
 
 // Delete deletes a redirect URL for a project environment
@@ -105,5 +117,8 @@ func (c *RedirectURLsClient) Delete(
 		nil,
 		nil,
 		&res)
-	return &res, err
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
 }

--- a/pkg/api/redirecturls_test.go
+++ b/pkg/api/redirecturls_test.go
@@ -1,0 +1,460 @@
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/redirecturls"
+)
+
+const (
+	testRedirectURL1 = "https://localhost:3000/callback"
+	testRedirectURL2 = "https://localhost:3001/auth/callback"
+	testRedirectURL3 = "https://localhost:3002/login"
+)
+
+func TestRedirectURLsClient_Create(t *testing.T) {
+	t.Run("create redirect URL with single type", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.RedirectURLs.Create(ctx, redirecturls.CreateRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         testRedirectURL1,
+			ValidTypes: []redirecturls.URLRedirectType{
+				{
+					Type:      redirecturls.RedirectTypeLogin,
+					IsDefault: true,
+				},
+			},
+			DoNotPromoteDefaults: false,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, testRedirectURL1, resp.RedirectURL.URL)
+		assert.Len(t, resp.RedirectURL.ValidTypes, 1)
+		assert.Equal(t, redirecturls.RedirectTypeLogin, resp.RedirectURL.ValidTypes[0].Type)
+		assert.True(t, resp.RedirectURL.ValidTypes[0].IsDefault)
+	})
+
+	t.Run("create redirect URL with multiple types", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.RedirectURLs.Create(ctx, redirecturls.CreateRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         testRedirectURL2,
+			ValidTypes: []redirecturls.URLRedirectType{
+				{
+					Type:      redirecturls.RedirectTypeLogin,
+					IsDefault: true,
+				},
+				{
+					Type:      redirecturls.RedirectTypeSignup,
+					IsDefault: false,
+				},
+				{
+					Type:      redirecturls.RedirectTypeInvite,
+					IsDefault: true,
+				},
+			},
+			DoNotPromoteDefaults: false,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, testRedirectURL2, resp.RedirectURL.URL)
+		assert.Len(t, resp.RedirectURL.ValidTypes, 3)
+
+		// Check that all types are present
+		typeMap := make(map[redirecturls.RedirectType]bool)
+		for _, validType := range resp.RedirectURL.ValidTypes {
+			typeMap[validType.Type] = validType.IsDefault
+		}
+		assert.Contains(t, typeMap, redirecturls.RedirectTypeLogin)
+		assert.Contains(t, typeMap, redirecturls.RedirectTypeSignup)
+		assert.Contains(t, typeMap, redirecturls.RedirectTypeInvite)
+	})
+
+	t.Run("create redirect URL with do not promote defaults", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.RedirectURLs.Create(ctx, redirecturls.CreateRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         testRedirectURL3,
+			ValidTypes: []redirecturls.URLRedirectType{
+				{
+					Type:      redirecturls.RedirectTypeResetPassword,
+					IsDefault: false,
+				},
+			},
+			DoNotPromoteDefaults: true,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, testRedirectURL3, resp.RedirectURL.URL)
+		assert.Len(t, resp.RedirectURL.ValidTypes, 1)
+		assert.Equal(t, redirecturls.RedirectTypeResetPassword, resp.RedirectURL.ValidTypes[0].Type)
+	})
+
+	t.Run("create duplicate redirect URL", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		duplicateURL := "https://duplicate.example.com/callback"
+
+		// Create first redirect URL
+		_, err := client.RedirectURLs.Create(ctx, redirecturls.CreateRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         duplicateURL,
+			ValidTypes: []redirecturls.URLRedirectType{
+				{
+					Type:      redirecturls.RedirectTypeLogin,
+					IsDefault: true,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Act
+		// Try to create the same URL again - should succeed but update the existing one
+		_, err = client.RedirectURLs.Create(ctx, redirecturls.CreateRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         duplicateURL,
+			ValidTypes: []redirecturls.URLRedirectType{
+				{
+					Type:      redirecturls.RedirectTypeSignup,
+					IsDefault: true,
+				},
+			},
+		})
+
+		getresp, geterr := client.RedirectURLs.Get(ctx, redirecturls.GetRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         duplicateURL,
+		})
+		require.NoError(t, geterr)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Len(t, getresp.RedirectURL.ValidTypes, 2)
+	})
+}
+
+func TestRedirectURLsClient_GetAll(t *testing.T) {
+	t.Run("get all redirect URLs", func(t *testing.T) {
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Create multiple redirect URLs
+		url1 := "https://getall1.example.com/callback"
+		url2 := "https://getall2.example.com/callback"
+
+		_, err := client.RedirectURLs.Create(ctx, redirecturls.CreateRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         url1,
+			ValidTypes: []redirecturls.URLRedirectType{
+				{
+					Type:      redirecturls.RedirectTypeLogin,
+					IsDefault: true,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = client.RedirectURLs.Create(ctx, redirecturls.CreateRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         url2,
+			ValidTypes: []redirecturls.URLRedirectType{
+				{
+					Type:      redirecturls.RedirectTypeSignup,
+					IsDefault: true,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		resp, err := client.RedirectURLs.GetAll(ctx, redirecturls.GetAllRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+		})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.GreaterOrEqual(t, len(resp.RedirectURLs), 2)
+
+		// Check that both URLs are present
+		urlMap := make(map[string]bool)
+		for _, redirectURL := range resp.RedirectURLs {
+			urlMap[redirectURL.URL] = true
+		}
+		assert.Contains(t, urlMap, url1)
+		assert.Contains(t, urlMap, url2)
+	})
+
+	t.Run("get all redirect URLs for empty project", func(t *testing.T) {
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		resp, err := client.RedirectURLs.GetAll(ctx, redirecturls.GetAllRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+		})
+
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+		// Environments come with one default redirect URL
+		assert.LessOrEqual(t, len(resp.RedirectURLs), 1)
+	})
+}
+
+func TestRedirectURLsClient_Get(t *testing.T) {
+	t.Run("get existing redirect URL", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		getURL := "https://get.example.com/callback"
+
+		// Create redirect URL first
+		createResp, err := client.RedirectURLs.Create(ctx, redirecturls.CreateRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         getURL,
+			ValidTypes: []redirecturls.URLRedirectType{
+				{
+					Type:      redirecturls.RedirectTypeLogin,
+					IsDefault: true,
+				},
+				{
+					Type:      redirecturls.RedirectTypeInvite,
+					IsDefault: false,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.RedirectURLs.Get(ctx, redirecturls.GetRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         getURL,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, createResp.RedirectURL.URL, resp.RedirectURL.URL)
+		assert.Len(t, resp.RedirectURL.ValidTypes, 2)
+
+		// Verify the types match
+		typeMap := make(map[redirecturls.RedirectType]bool)
+		for _, validType := range resp.RedirectURL.ValidTypes {
+			typeMap[validType.Type] = validType.IsDefault
+		}
+		assert.Contains(t, typeMap, redirecturls.RedirectTypeLogin)
+		assert.Contains(t, typeMap, redirecturls.RedirectTypeInvite)
+		assert.True(t, typeMap[redirecturls.RedirectTypeLogin])
+		assert.False(t, typeMap[redirecturls.RedirectTypeInvite])
+	})
+
+	t.Run("get non-existent redirect URL", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.RedirectURLs.Get(ctx, redirecturls.GetRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         "https://nonexistent.example.com/callback",
+		})
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestRedirectURLsClient_Update(t *testing.T) {
+	t.Run("update redirect URL valid types", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		updateURL := "https://update.example.com/callback"
+
+		// Create redirect URL first
+		_, err := client.RedirectURLs.Create(ctx, redirecturls.CreateRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         updateURL,
+			ValidTypes: []redirecturls.URLRedirectType{
+				{
+					Type:      redirecturls.RedirectTypeLogin,
+					IsDefault: true,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Act
+		// Update with different types
+		resp, err := client.RedirectURLs.Update(ctx, redirecturls.UpdateRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         updateURL,
+			ValidTypes: []redirecturls.URLRedirectType{
+				{
+					Type:      redirecturls.RedirectTypeLogin,
+					IsDefault: true,
+				},
+				{
+					Type:      redirecturls.RedirectTypeSignup,
+					IsDefault: true,
+				},
+				{
+					Type:      redirecturls.RedirectTypeResetPassword,
+					IsDefault: false,
+				},
+			},
+			DoNotPromoteDefaults: false,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, updateURL, resp.RedirectURL.URL)
+		assert.Len(t, resp.RedirectURL.ValidTypes, 3)
+
+		// Verify all types are present
+		typeMap := make(map[redirecturls.RedirectType]bool)
+		for _, validType := range resp.RedirectURL.ValidTypes {
+			typeMap[validType.Type] = validType.IsDefault
+		}
+		assert.Contains(t, typeMap, redirecturls.RedirectTypeLogin)
+		assert.Contains(t, typeMap, redirecturls.RedirectTypeSignup)
+		assert.Contains(t, typeMap, redirecturls.RedirectTypeResetPassword)
+	})
+
+	t.Run("update non-existent redirect URL", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.RedirectURLs.Update(ctx, redirecturls.UpdateRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         "https://nonexistent-update.example.com/callback",
+			ValidTypes: []redirecturls.URLRedirectType{
+				{
+					Type:      redirecturls.RedirectTypeLogin,
+					IsDefault: true,
+				},
+			},
+		})
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestRedirectURLsClient_Delete(t *testing.T) {
+	t.Run("delete existing redirect URL", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		deleteURL := "https://delete.example.com/callback"
+
+		// Create redirect URL first
+		_, err := client.RedirectURLs.Create(ctx, redirecturls.CreateRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         deleteURL,
+			ValidTypes: []redirecturls.URLRedirectType{
+				{
+					Type:      redirecturls.RedirectTypeLogin,
+					IsDefault: true,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.RedirectURLs.Delete(ctx, redirecturls.DeleteRequest{
+			Project:              project.Project,
+			Environment:          TestEnvironment,
+			URL:                  deleteURL,
+			DoNotPromoteDefaults: false,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify redirect URL is deleted
+		_, err = client.RedirectURLs.Get(ctx, redirecturls.GetRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         deleteURL,
+		})
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "404")
+	})
+
+	t.Run("delete non-existent redirect URL", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.RedirectURLs.Delete(ctx, redirecturls.DeleteRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			URL:         "https://nonexistent-delete.example.com/callback",
+		})
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}

--- a/pkg/api/trustedtokenprofiles_test.go
+++ b/pkg/api/trustedtokenprofiles_test.go
@@ -1,0 +1,510 @@
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/trustedtokenprofiles"
+)
+
+const (
+	// Sample JWK for testing
+	testJWKSURL = "https://example.com/.well-known/jwks.json"
+
+	// Sample PEM public key for testing
+	testPEMKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+-----END PUBLIC KEY-----`
+)
+
+func TestTrustedTokenProfilesClient_Create(t *testing.T) {
+	t.Run("create with JWK", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		jwksURL := testJWKSURL
+
+		// Act
+		resp, err := client.TrustedTokenProfiles.Create(ctx, &trustedtokenprofiles.CreateTrustedTokenProfileRequest{
+			Project:         project.Project,
+			Environment:     TestEnvironment,
+			Name:            "Test JWK Profile",
+			Audience:        "test-audience",
+			Issuer:          "test-issuer",
+			JwksURL:         &jwksURL,
+			PublicKeyType:   "jwk",
+			PEMFiles:        []string{},
+			CanJITProvision: true,
+			AttributeMapping: map[string]interface{}{
+				"user_id": "sub",
+				"email":   "email",
+			},
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, "Test JWK Profile", resp.TrustedTokenProfile.Name)
+		assert.Equal(t, "test-audience", resp.TrustedTokenProfile.Audience)
+		assert.Equal(t, "test-issuer", resp.TrustedTokenProfile.Issuer)
+		assert.Equal(t, testJWKSURL, resp.TrustedTokenProfile.JwksURL)
+		assert.Equal(t, "jwk", resp.TrustedTokenProfile.PublicKeyType)
+		assert.NotEmpty(t, resp.TrustedTokenProfile.ID)
+	})
+
+	t.Run("create with PEM files", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.TrustedTokenProfiles.Create(ctx, &trustedtokenprofiles.CreateTrustedTokenProfileRequest{
+			Project:         project.Project,
+			Environment:     TestEnvironment,
+			Name:            "Test PEM Profile",
+			Audience:        "test-audience-pem",
+			Issuer:          "test-issuer-pem",
+			PublicKeyType:   "pem",
+			PEMFiles:        []string{testPEMKey},
+			CanJITProvision: false,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, "Test PEM Profile", resp.TrustedTokenProfile.Name)
+		assert.Equal(t, "test-audience-pem", resp.TrustedTokenProfile.Audience)
+		assert.Equal(t, "test-issuer-pem", resp.TrustedTokenProfile.Issuer)
+		assert.Equal(t, "pem", resp.TrustedTokenProfile.PublicKeyType)
+		assert.NotEmpty(t, resp.TrustedTokenProfile.ID)
+		assert.Len(t, resp.TrustedTokenProfile.PEMFiles, 1)
+	})
+}
+
+func TestTrustedTokenProfilesClient_Get(t *testing.T) {
+	t.Run("get existing profile", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		jwksURL := testJWKSURL
+		createResp, err := client.TrustedTokenProfiles.Create(ctx, &trustedtokenprofiles.CreateTrustedTokenProfileRequest{
+			Project:         project.Project,
+			Environment:     TestEnvironment,
+			Name:            "Test Get Profile",
+			Audience:        "get-test-audience",
+			Issuer:          "get-test-issuer.com",
+			JwksURL:         &jwksURL,
+			PublicKeyType:   "jwk",
+			PEMFiles:        []string{},
+			CanJITProvision: false,
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.TrustedTokenProfiles.Get(ctx, &trustedtokenprofiles.GetTrustedTokenProfileRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			ProfileID:   createResp.TrustedTokenProfile.ID,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, createResp.TrustedTokenProfile.ID, resp.TrustedTokenProfile.ID)
+		assert.Equal(t, "Test Get Profile", resp.TrustedTokenProfile.Name)
+		assert.Equal(t, "get-test-audience", resp.TrustedTokenProfile.Audience)
+		assert.Equal(t, "get-test-issuer.com", resp.TrustedTokenProfile.Issuer)
+	})
+
+	t.Run("get non-existent profile", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.TrustedTokenProfiles.Get(ctx, &trustedtokenprofiles.GetTrustedTokenProfileRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			ProfileID:   "non-existent-profile-id",
+		})
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestTrustedTokenProfilesClient_List(t *testing.T) {
+	t.Run("list profiles", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		jwksURL := testJWKSURL
+
+		profile1, err := client.TrustedTokenProfiles.Create(ctx, &trustedtokenprofiles.CreateTrustedTokenProfileRequest{
+			Project:         project.Project,
+			Environment:     TestEnvironment,
+			Name:            "List Test Profile 1",
+			Audience:        "list-test-audience-1",
+			Issuer:          "list-test-issuer-1",
+			JwksURL:         &jwksURL,
+			PublicKeyType:   "jwk",
+			PEMFiles:        []string{},
+			CanJITProvision: true,
+		})
+		require.NoError(t, err)
+
+		profile2, err := client.TrustedTokenProfiles.Create(ctx, &trustedtokenprofiles.CreateTrustedTokenProfileRequest{
+			Project:         project.Project,
+			Environment:     TestEnvironment,
+			Name:            "List Test Profile 2",
+			Audience:        "list-test-audience-2",
+			Issuer:          "list-test-issuer-2",
+			PublicKeyType:   "pem",
+			PEMFiles:        []string{testPEMKey},
+			CanJITProvision: false,
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.TrustedTokenProfiles.List(ctx, &trustedtokenprofiles.ListTrustedTokenProfilesRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Len(t, resp.TrustedTokenProfiles, 2)
+
+		var foundProfile1, foundProfile2 bool
+		for _, profile := range resp.TrustedTokenProfiles {
+			if profile.ID == profile1.TrustedTokenProfile.ID {
+				foundProfile1 = true
+				assert.Equal(t, "List Test Profile 1", profile.Name)
+			}
+			if profile.ID == profile2.TrustedTokenProfile.ID {
+				foundProfile2 = true
+				assert.Equal(t, "List Test Profile 2", profile.Name)
+			}
+		}
+		assert.True(t, foundProfile1)
+		assert.True(t, foundProfile2)
+	})
+}
+
+func TestTrustedTokenProfilesClient_Update(t *testing.T) {
+	t.Run("update profile name and audience", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		jwksURL := testJWKSURL
+		createResp, err := client.TrustedTokenProfiles.Create(ctx, &trustedtokenprofiles.CreateTrustedTokenProfileRequest{
+			Project:         project.Project,
+			Environment:     TestEnvironment,
+			Name:            "Update Test Profile",
+			Audience:        "update-test-audience",
+			Issuer:          "update-test-issuer",
+			JwksURL:         &jwksURL,
+			PublicKeyType:   "jwk",
+			PEMFiles:        []string{},
+			CanJITProvision: true,
+		})
+		require.NoError(t, err)
+
+		updatedName := "Updated Profile Name"
+		updatedAudience := "updated-audience"
+		updatedJITProvision := false
+
+		// Act
+		resp, err := client.TrustedTokenProfiles.Update(ctx, &trustedtokenprofiles.UpdateTrustedTokenProfileRequest{
+			Project:         project.Project,
+			Environment:     TestEnvironment,
+			ProfileID:       createResp.TrustedTokenProfile.ID,
+			Name:            &updatedName,
+			Audience:        &updatedAudience,
+			CanJITProvision: &updatedJITProvision,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, createResp.TrustedTokenProfile.ID, resp.TrustedTokenProfile.ID)
+		assert.Equal(t, "Updated Profile Name", resp.TrustedTokenProfile.Name)
+		assert.Equal(t, "updated-audience", resp.TrustedTokenProfile.Audience)
+		assert.Equal(t, "update-test-issuer", resp.TrustedTokenProfile.Issuer) // Should remain unchanged
+	})
+}
+
+func TestTrustedTokenProfilesClient_Delete(t *testing.T) {
+	t.Run("delete existing profile", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		jwksURL := testJWKSURL
+		createResp, err := client.TrustedTokenProfiles.Create(ctx, &trustedtokenprofiles.CreateTrustedTokenProfileRequest{
+			Project:         project.Project,
+			Environment:     TestEnvironment,
+			Name:            "Delete Test Profile",
+			Audience:        "delete-test-audience",
+			Issuer:          "delete-test-issuer",
+			JwksURL:         &jwksURL,
+			PublicKeyType:   "jwk",
+			PEMFiles:        []string{},
+			CanJITProvision: true,
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.TrustedTokenProfiles.Delete(ctx, &trustedtokenprofiles.DeleteTrustedTokenProfileRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			ProfileID:   createResp.TrustedTokenProfile.ID,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify profile is deleted
+		getResp, err := client.TrustedTokenProfiles.Get(ctx, &trustedtokenprofiles.GetTrustedTokenProfileRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			ProfileID:   createResp.TrustedTokenProfile.ID,
+		})
+		assert.Error(t, err)
+		assert.Nil(t, getResp)
+	})
+}
+
+func TestTrustedTokenProfilesClient_CreatePEM(t *testing.T) {
+	t.Run("create PEM file for existing PEM profile", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Create a profile first with initial PEM file
+		profileResp, err := client.TrustedTokenProfiles.Create(ctx, &trustedtokenprofiles.CreateTrustedTokenProfileRequest{
+			Project:         project.Project,
+			Environment:     TestEnvironment,
+			Name:            "PEM Test Profile",
+			Audience:        "pem-test-audience",
+			Issuer:          "pem-test-issuer",
+			PublicKeyType:   "pem",
+			PEMFiles:        []string{testPEMKey},
+			CanJITProvision: true,
+		})
+		require.NoError(t, err)
+
+		// Act
+		// Add another PEM file to the profile
+		resp, err := client.TrustedTokenProfiles.CreatePEM(ctx, &trustedtokenprofiles.CreatePEMFileRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			ProfileID:   profileResp.TrustedTokenProfile.ID,
+			PublicKey:   testPEMKey,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.NotEmpty(t, resp.PEMFile.ID)
+		assert.Equal(t, testPEMKey, resp.PEMFile.PublicKey)
+	})
+
+	t.Run("create PEM file for JWK profile", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		jwksURL := testJWKSURL
+		// Create a JWK profile first
+		profileResp, err := client.TrustedTokenProfiles.Create(ctx, &trustedtokenprofiles.CreateTrustedTokenProfileRequest{
+			Project:         project.Project,
+			Environment:     TestEnvironment,
+			Name:            "JWK to PEM Test Profile",
+			Audience:        "jwk-pem-test-audience",
+			Issuer:          "jwk-pem-test-issuer",
+			JwksURL:         &jwksURL,
+			PublicKeyType:   "jwk",
+			PEMFiles:        []string{},
+			CanJITProvision: true,
+		})
+		require.NoError(t, err)
+
+		// Act
+		// Try to add a PEM file to the JWK profile
+		resp, err := client.TrustedTokenProfiles.CreatePEM(ctx, &trustedtokenprofiles.CreatePEMFileRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			ProfileID:   profileResp.TrustedTokenProfile.ID,
+			PublicKey:   testPEMKey,
+		})
+
+		// Arrange
+		// This should fail since the trusted token profile key is not compatible
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+
+	t.Run("create PEM file for non-existent profile", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.TrustedTokenProfiles.CreatePEM(ctx, &trustedtokenprofiles.CreatePEMFileRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			ProfileID:   "non-existent-profile-id",
+			PublicKey:   testPEMKey,
+		})
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestTrustedTokenProfilesClient_GetPEM(t *testing.T) {
+	t.Run("get existing PEM file", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Create a profile first with initial PEM file
+		profileResp, err := client.TrustedTokenProfiles.Create(ctx, &trustedtokenprofiles.CreateTrustedTokenProfileRequest{
+			Project:         project.Project,
+			Environment:     TestEnvironment,
+			Name:            "PEM Get Test Profile",
+			Audience:        "pem-get-test-audience",
+			Issuer:          "pem-get-test-issuer",
+			PublicKeyType:   "pem",
+			PEMFiles:        []string{testPEMKey},
+			CanJITProvision: true,
+		})
+		require.NoError(t, err)
+
+		// Use the PEM file that was created with the profile
+		pemFileID := profileResp.TrustedTokenProfile.PEMFiles[0].ID
+
+		// Act
+		resp, err := client.TrustedTokenProfiles.GetPEM(ctx, &trustedtokenprofiles.GetPEMFileRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			ProfileID:   profileResp.TrustedTokenProfile.ID,
+			PEMFileID:   pemFileID,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, pemFileID, resp.PEMFile.ID)
+		assert.Equal(t, testPEMKey, resp.PEMFile.PublicKey)
+	})
+
+	t.Run("get non-existent PEM file", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Create a profile first with initial PEM file
+		profileResp, err := client.TrustedTokenProfiles.Create(ctx, &trustedtokenprofiles.CreateTrustedTokenProfileRequest{
+			Project:         project.Project,
+			Environment:     TestEnvironment,
+			Name:            "PEM Get Test Profile",
+			Audience:        "pem-get-test-audience",
+			Issuer:          "pem-get-test-issuer",
+			PublicKeyType:   "pem",
+			PEMFiles:        []string{testPEMKey},
+			CanJITProvision: true,
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.TrustedTokenProfiles.GetPEM(ctx, &trustedtokenprofiles.GetPEMFileRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			ProfileID:   profileResp.TrustedTokenProfile.ID,
+			PEMFileID:   "non-existent-pem-file-id",
+		})
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestTrustedTokenProfilesClient_DeletePEM(t *testing.T) {
+	t.Run("delete existing PEM file", func(t *testing.T) {
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Create a profile first with two PEM files so we can delete one
+		profileResp, err := client.TrustedTokenProfiles.Create(ctx, &trustedtokenprofiles.CreateTrustedTokenProfileRequest{
+			Project:         project.Project,
+			Environment:     TestEnvironment,
+			Name:            "PEM Delete Test Profile",
+			Audience:        "pem-delete-test-audience",
+			Issuer:          "pem-delete-test-issuer",
+			PublicKeyType:   "pem",
+			PEMFiles:        []string{testPEMKey},
+			CanJITProvision: true,
+		})
+		require.NoError(t, err)
+
+		// Add another PEM file so we can delete one
+		createPEMResp, err := client.TrustedTokenProfiles.CreatePEM(ctx, &trustedtokenprofiles.CreatePEMFileRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			ProfileID:   profileResp.TrustedTokenProfile.ID,
+			PublicKey:   testPEMKey,
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.TrustedTokenProfiles.DeletePEM(ctx, &trustedtokenprofiles.DeletePEMFileRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			ProfileID:   profileResp.TrustedTokenProfile.ID,
+			PEMFileID:   createPEMResp.PEMFile.ID,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Assert
+		// Verify PEM file is deleted
+		getProfileResp, err := client.TrustedTokenProfiles.Get(ctx, &trustedtokenprofiles.GetTrustedTokenProfileRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			ProfileID:   profileResp.TrustedTokenProfile.ID,
+		})
+		require.NoError(t, err)
+
+		assert.Len(t, getProfileResp.TrustedTokenProfile.PEMFiles, 1)
+		assert.NotEqual(t, createPEMResp.PEMFile.ID, getProfileResp.TrustedTokenProfile.PEMFiles[0].ID)
+	})
+}

--- a/pkg/models/trustedtokenprofiles/types.go
+++ b/pkg/models/trustedtokenprofiles/types.go
@@ -73,7 +73,7 @@ type GetTrustedTokenProfileResponse struct {
 	// RequestID is a unique identifier to help with debugging the request
 	RequestID string `json:"request_id"`
 	// TrustedTokenProfile is the trusted token profile that was retrieved
-	TrustedTokenProfile TrustedTokenProfile `json:"trusted_token_profile"`
+	TrustedTokenProfile TrustedTokenProfile `json:"profile"`
 }
 
 type ListTrustedTokenProfilesRequest struct {
@@ -89,7 +89,7 @@ type ListTrustedTokenProfilesResponse struct {
 	// RequestID is a unique identifier to help with debugging the request
 	RequestID string `json:"request_id"`
 	// TrustedTokenProfiles is a list of all trusted token profiles for the project
-	TrustedTokenProfiles []TrustedTokenProfile `json:"trusted_token_profiles"`
+	TrustedTokenProfiles []TrustedTokenProfile `json:"profiles"`
 }
 
 type UpdateTrustedTokenProfileRequest struct {


### PR DESCRIPTION
## Description

New tests:
- Redirect URL
- Trusted token profiles
- PEM files

Fixed:
- Error handling for redirect url
- `/all` path for redirect url's `GetAll`
- Correct json attribute `profile` for trusted token profiles


## Tests
Added tests

```
=== RUN   TestRedirectURLsClient_Create
=== RUN   TestRedirectURLsClient_Create/create_redirect_URL_with_single_type
=== RUN   TestRedirectURLsClient_Create/create_redirect_URL_with_multiple_types
=== RUN   TestRedirectURLsClient_Create/create_redirect_URL_with_do_not_promote_defaults
=== RUN   TestRedirectURLsClient_Create/create_duplicate_redirect_URL
--- PASS: TestRedirectURLsClient_Create (2.55s)
    --- PASS: TestRedirectURLsClient_Create/create_redirect_URL_with_single_type (0.57s)
    --- PASS: TestRedirectURLsClient_Create/create_redirect_URL_with_multiple_types (0.59s)
    --- PASS: TestRedirectURLsClient_Create/create_redirect_URL_with_do_not_promote_defaults (0.56s)
    --- PASS: TestRedirectURLsClient_Create/create_duplicate_redirect_URL (0.83s)
=== RUN   TestRedirectURLsClient_GetAll
=== RUN   TestRedirectURLsClient_GetAll/get_all_redirect_URLs
=== RUN   TestRedirectURLsClient_GetAll/get_all_redirect_URLs_for_empty_project
--- PASS: TestRedirectURLsClient_GetAll (1.36s)
    --- PASS: TestRedirectURLsClient_GetAll/get_all_redirect_URLs (0.82s)
    --- PASS: TestRedirectURLsClient_GetAll/get_all_redirect_URLs_for_empty_project (0.53s)
=== RUN   TestRedirectURLsClient_Get
=== RUN   TestRedirectURLsClient_Get/get_existing_redirect_URL
=== RUN   TestRedirectURLsClient_Get/get_non-existent_redirect_URL
--- PASS: TestRedirectURLsClient_Get (1.25s)
    --- PASS: TestRedirectURLsClient_Get/get_existing_redirect_URL (0.72s)
    --- PASS: TestRedirectURLsClient_Get/get_non-existent_redirect_URL (0.53s)
=== RUN   TestRedirectURLsClient_Update
=== RUN   TestRedirectURLsClient_Update/update_redirect_URL_valid_types
=== RUN   TestRedirectURLsClient_Update/update_non-existent_redirect_URL
--- PASS: TestRedirectURLsClient_Update (1.28s)
    --- PASS: TestRedirectURLsClient_Update/update_redirect_URL_valid_types (0.75s)
    --- PASS: TestRedirectURLsClient_Update/update_non-existent_redirect_URL (0.53s)
=== RUN   TestRedirectURLsClient_Delete
=== RUN   TestRedirectURLsClient_Delete/delete_existing_redirect_URL
=== RUN   TestRedirectURLsClient_Delete/delete_non-existent_redirect_URL
--- PASS: TestRedirectURLsClient_Delete (1.34s)
    --- PASS: TestRedirectURLsClient_Delete/delete_existing_redirect_URL (0.80s)
    --- PASS: TestRedirectURLsClient_Delete/delete_non-existent_redirect_URL (0.54s)
=== RUN   TestSecretsClient_CreateSecret
=== RUN   TestSecretsClient_CreateSecret/create_secret
--- PASS: TestSecretsClient_CreateSecret (0.55s)
    --- PASS: TestSecretsClient_CreateSecret/create_secret (0.55s)
=== RUN   TestSecretsClient_GetSecret
=== RUN   TestSecretsClient_GetSecret/get_existing_secret
=== RUN   TestSecretsClient_GetSecret/secret_does_not_exist
--- PASS: TestSecretsClient_GetSecret (1.16s)
    --- PASS: TestSecretsClient_GetSecret/get_existing_secret (0.64s)
    --- PASS: TestSecretsClient_GetSecret/secret_does_not_exist (0.52s)
=== RUN   TestSecretsClient_GetAllSecrets
=== RUN   TestSecretsClient_GetAllSecrets/get_all_secrets
=== RUN   TestSecretsClient_GetAllSecrets/only_the_default_secret_exists
--- PASS: TestSecretsClient_GetAllSecrets (1.40s)
    --- PASS: TestSecretsClient_GetAllSecrets/get_all_secrets (0.88s)
    --- PASS: TestSecretsClient_GetAllSecrets/only_the_default_secret_exists (0.52s)
=== RUN   TestSecretsClient_DeleteSecret
=== RUN   TestSecretsClient_DeleteSecret/delete_existing_secret
=== RUN   TestSecretsClient_DeleteSecret/secret_does_not_exist
--- PASS: TestSecretsClient_DeleteSecret (1.29s)
    --- PASS: TestSecretsClient_DeleteSecret/delete_existing_secret (0.76s)
    --- PASS: TestSecretsClient_DeleteSecret/secret_does_not_exist (0.53s)
=== RUN   TestTrustedTokenProfilesClient_Create
=== RUN   TestTrustedTokenProfilesClient_Create/create_with_JWK
=== RUN   TestTrustedTokenProfilesClient_Create/create_with_PEM_files
--- PASS: TestTrustedTokenProfilesClient_Create (1.09s)
    --- PASS: TestTrustedTokenProfilesClient_Create/create_with_JWK (0.54s)
    --- PASS: TestTrustedTokenProfilesClient_Create/create_with_PEM_files (0.55s)
=== RUN   TestTrustedTokenProfilesClient_Get
=== RUN   TestTrustedTokenProfilesClient_Get/get_existing_profile
=== RUN   TestTrustedTokenProfilesClient_Get/get_non-existent_profile
--- PASS: TestTrustedTokenProfilesClient_Get (1.18s)
    --- PASS: TestTrustedTokenProfilesClient_Get/get_existing_profile (0.66s)
    --- PASS: TestTrustedTokenProfilesClient_Get/get_non-existent_profile (0.52s)
=== RUN   TestTrustedTokenProfilesClient_List
=== RUN   TestTrustedTokenProfilesClient_List/list_profiles
--- PASS: TestTrustedTokenProfilesClient_List (0.80s)
    --- PASS: TestTrustedTokenProfilesClient_List/list_profiles (0.80s)
=== RUN   TestTrustedTokenProfilesClient_Update
=== RUN   TestTrustedTokenProfilesClient_Update/update_profile_name_and_audience
--- PASS: TestTrustedTokenProfilesClient_Update (0.67s)
    --- PASS: TestTrustedTokenProfilesClient_Update/update_profile_name_and_audience (0.67s)
=== RUN   TestTrustedTokenProfilesClient_Delete
=== RUN   TestTrustedTokenProfilesClient_Delete/delete_existing_profile
--- PASS: TestTrustedTokenProfilesClient_Delete (0.78s)
    --- PASS: TestTrustedTokenProfilesClient_Delete/delete_existing_profile (0.78s)
=== RUN   TestTrustedTokenProfilesClient_CreatePEM
=== RUN   TestTrustedTokenProfilesClient_CreatePEM/create_PEM_file_for_existing_PEM_profile
=== RUN   TestTrustedTokenProfilesClient_CreatePEM/create_PEM_file_for_JWK_profile
=== RUN   TestTrustedTokenProfilesClient_CreatePEM/create_PEM_file_for_non-existent_profile
--- PASS: TestTrustedTokenProfilesClient_CreatePEM (1.85s)
    --- PASS: TestTrustedTokenProfilesClient_CreatePEM/create_PEM_file_for_existing_PEM_profile (0.67s)
    --- PASS: TestTrustedTokenProfilesClient_CreatePEM/create_PEM_file_for_JWK_profile (0.65s)
    --- PASS: TestTrustedTokenProfilesClient_CreatePEM/create_PEM_file_for_non-existent_profile (0.53s)
=== RUN   TestTrustedTokenProfilesClient_GetPEM
=== RUN   TestTrustedTokenProfilesClient_GetPEM/get_existing_PEM_file
=== RUN   TestTrustedTokenProfilesClient_GetPEM/get_non-existent_PEM_file
--- PASS: TestTrustedTokenProfilesClient_GetPEM (1.38s)
    --- PASS: TestTrustedTokenProfilesClient_GetPEM/get_existing_PEM_file (0.71s)
    --- PASS: TestTrustedTokenProfilesClient_GetPEM/get_non-existent_PEM_file (0.67s)
=== RUN   TestTrustedTokenProfilesClient_DeletePEM
=== RUN   TestTrustedTokenProfilesClient_DeletePEM/delete_existing_PEM_file
--- PASS: TestTrustedTokenProfilesClient_DeletePEM (0.91s)
    --- PASS: TestTrustedTokenProfilesClient_DeletePEM/delete_existing_PEM_file (0.91s)
```

