### PR TITLE
[v3] Support for RBAC Policy

### DIFF
--- a/pkg/api/rbacpolicy.go
+++ b/pkg/api/rbacpolicy.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
 
 	"github.com/stytchauth/stytch-management-go/v3/pkg/api/internal"
 	"github.com/stytchauth/stytch-management-go/v3/pkg/models/rbacpolicy"
@@ -18,17 +20,26 @@ func newRBACPolicyClient(c *internal.Client) *RBACPolicyClient {
 	}
 }
 
-// Get retrieves the RBAC policy for a project
+// Get retrieves the RBAC policy for an environment.
 func (c *RBACPolicyClient) Get(
 	ctx context.Context,
 	body rbacpolicy.GetRequest,
 ) (*rbacpolicy.GetResponse, error) {
-	var res rbacpolicy.GetResponse
-	err := c.client.NewRequest(ctx, "GET", "/pwa/v3/projects/"+body.Project+"/environments/"+body.Environment+"/rbac_policy", nil, nil, &res)
-	return &res, err
+	var resp rbacpolicy.GetResponse
+	err := c.client.NewRequest(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/rbac_policy", body.Project, body.Environment),
+		nil,
+		nil,
+		&resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, err
 }
 
-// Set updates the RBAC policy for a project
+// Set updates the RBAC policy for an environment.
 func (c *RBACPolicyClient) Set(
 	ctx context.Context,
 	body rbacpolicy.SetRequest,
@@ -38,7 +49,16 @@ func (c *RBACPolicyClient) Set(
 		return nil, err
 	}
 
-	var res rbacpolicy.SetResponse
-	err = c.client.NewRequest(ctx, "PUT", "/pwa/v3/projects/"+body.Project+"/environments/"+body.Environment+"/rbac_policy", nil, jsonBody, &res)
-	return &res, err
+	var resp rbacpolicy.SetResponse
+	err = c.client.NewRequest(
+		ctx,
+		http.MethodPut,
+		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/rbac_policy", body.Project, body.Environment),
+		nil,
+		jsonBody,
+		&resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, err
 }

--- a/pkg/api/rbacpolicy_test.go
+++ b/pkg/api/rbacpolicy_test.go
@@ -1,0 +1,359 @@
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/environments"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/rbacpolicy"
+)
+
+func getTestB2BPolicy(
+	t *testing.T, client *testClient, project string, env string,
+) rbacpolicy.Policy {
+	t.Helper()
+	// The StytchMember and StytchAdmin RoleIDs and Descriptions cannot be modified, so we first
+	// look up their current values when constructing our new RBAC policy.
+	resp, err := client.RBACPolicy.Get(context.Background(), rbacpolicy.GetRequest{
+		Project:     project,
+		Environment: env,
+	})
+	require.NoError(t, err)
+
+	// Define some custom resources.
+	resources := []rbacpolicy.Resource{
+		{
+			ResourceID:       "resource1",
+			Description:      "Resource 1",
+			AvailableActions: []string{"read", "write", "delete"},
+		},
+		{
+			ResourceID:       "resource2",
+			Description:      "Resource 2",
+			AvailableActions: []string{"read", "write"},
+		},
+		{
+			ResourceID:       "resource3",
+			Description:      "Resource 3",
+			AvailableActions: []string{"do_admin_things"},
+		},
+	}
+
+	// Define some custom scopes.
+	scopes := []rbacpolicy.Scope{
+		{
+			Scope:       "scope1",
+			Description: "Scope 1",
+			Permissions: []rbacpolicy.Permission{
+				{
+					ResourceID: "resource1",
+					Actions:    []string{"read", "write"},
+				},
+			},
+		},
+		{
+			Scope:       "scope2",
+			Description: "Scope 2",
+			Permissions: []rbacpolicy.Permission{
+				{
+					ResourceID: "resource2",
+					Actions:    []string{"read"},
+				},
+			},
+		},
+	}
+
+	// Add custom resources to default and custom roles.
+	admin := rbacpolicy.Role{
+		RoleID:      resp.Policy.StytchAdmin.RoleID,
+		Description: resp.Policy.StytchAdmin.Description,
+		Permissions: []rbacpolicy.Permission{
+			{
+				ResourceID: "resource1",
+				Actions:    []string{"read", "write", "delete"},
+			},
+			{
+				ResourceID: "resource2",
+				Actions:    []string{"read", "write"},
+			},
+			{
+				ResourceID: "resource3",
+				Actions:    []string{"do_admin_things"},
+			},
+		},
+	}
+	writer := rbacpolicy.Role{
+		RoleID: "writer_role",
+		Permissions: []rbacpolicy.Permission{
+			{
+				ResourceID: "resource1",
+				Actions:    []string{"read", "write"},
+			},
+			{
+				ResourceID: "resource2",
+				Actions:    []string{"read", "write"},
+			},
+		},
+	}
+	reader := rbacpolicy.Role{
+		RoleID:      resp.Policy.StytchMember.RoleID,
+		Description: resp.Policy.StytchMember.Description,
+		Permissions: []rbacpolicy.Permission{
+			{
+				ResourceID: "resource1",
+				Actions:    []string{"read"},
+			},
+			{
+				ResourceID: "resource2",
+				Actions:    []string{"read"},
+			},
+		},
+	}
+
+	return rbacpolicy.Policy{
+		StytchMember:    &reader,
+		StytchAdmin:     &admin,
+		CustomRoles:     []rbacpolicy.Role{writer},
+		CustomResources: resources,
+		CustomScopes:    scopes,
+	}
+}
+
+func getTestB2CPolicy(
+	t *testing.T, client *testClient, project string, env string,
+) rbacpolicy.Policy {
+	t.Helper()
+	// The StytchUser RoleID and Description cannot be modified, so we first look up its current
+	// values when constructing our new RBAC policy.
+	resp, err := client.RBACPolicy.Get(context.Background(), rbacpolicy.GetRequest{
+		Project:     project,
+		Environment: env,
+	})
+	require.NoError(t, err)
+
+	// Define some custom resources.
+	resources := []rbacpolicy.Resource{
+		{
+			ResourceID:       "resource1",
+			Description:      "Resource 1",
+			AvailableActions: []string{"read", "write", "delete"},
+		},
+		{
+			ResourceID:       "resource2",
+			Description:      "Resource 2",
+			AvailableActions: []string{"read", "write"},
+		},
+		{
+			ResourceID:       "resource3",
+			Description:      "Resource 3",
+			AvailableActions: []string{"do_admin_things"},
+		},
+	}
+
+	// Define some custom scopes.
+	scopes := []rbacpolicy.Scope{
+		{
+			Scope:       "scope1",
+			Description: "Scope 1",
+			Permissions: []rbacpolicy.Permission{
+				{
+					ResourceID: "resource1",
+					Actions:    []string{"read", "write"},
+				},
+			},
+		},
+		{
+			Scope:       "scope2",
+			Description: "Scope 2",
+			Permissions: []rbacpolicy.Permission{
+				{
+					ResourceID: "resource2",
+					Actions:    []string{"read"},
+				},
+			},
+		},
+	}
+
+	// Add custom resources to default and custom roles.
+	user := rbacpolicy.Role{
+		RoleID:      resp.Policy.StytchUser.RoleID,
+		Description: resp.Policy.StytchUser.Description,
+		Permissions: []rbacpolicy.Permission{
+			{
+				ResourceID: "resource1",
+				Actions:    []string{"read", "write", "delete"},
+			},
+			{
+				ResourceID: "resource2",
+				Actions:    []string{"read", "write"},
+			},
+			{
+				ResourceID: "resource3",
+				Actions:    []string{"do_admin_things"},
+			},
+		},
+	}
+
+	writer := rbacpolicy.Role{
+		RoleID: "writer_role",
+		Permissions: []rbacpolicy.Permission{
+			{
+				ResourceID: "resource1",
+				Actions:    []string{"read", "write"},
+			},
+			{
+				ResourceID: "resource2",
+				Actions:    []string{"read", "write"},
+			},
+		},
+	}
+
+	return rbacpolicy.Policy{
+		StytchUser:      &user,
+		CustomRoles:     []rbacpolicy.Role{writer},
+		CustomResources: resources,
+		CustomScopes:    scopes,
+	}
+}
+
+func TestRBACPolicyClient_Get(t *testing.T) {
+	t.Run("B2B policy", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		env := client.DisposableEnvironment(projects.VerticalB2B, environments.EnvironmentTypeTest)
+		policy := getTestB2BPolicy(t, client, env.Project, env.Environment)
+		_, err := client.RBACPolicy.Set(context.Background(), rbacpolicy.SetRequest{
+			Project:         env.Project,
+			Environment:     env.Environment,
+			StytchMember:    policy.StytchMember,
+			StytchAdmin:     policy.StytchAdmin,
+			CustomRoles:     policy.CustomRoles,
+			CustomResources: policy.CustomResources,
+			CustomScopes:    policy.CustomScopes,
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.RBACPolicy.Get(context.Background(), rbacpolicy.GetRequest{
+			Project:     env.Project,
+			Environment: env.Environment,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, policy.StytchMember, resp.Policy.StytchMember)
+		assert.Equal(t, policy.StytchAdmin, resp.Policy.StytchAdmin)
+		assert.Equal(t, policy.CustomRoles, resp.Policy.CustomRoles)
+		assert.Equal(t, policy.CustomResources, resp.Policy.CustomResources)
+		assert.Equal(t, policy.CustomScopes, resp.Policy.CustomScopes)
+	})
+	t.Run("B2C policy", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		env := client.DisposableEnvironment(projects.VerticalConsumer, environments.EnvironmentTypeTest)
+		policy := getTestB2CPolicy(t, client, env.Project, env.Environment)
+		_, err := client.RBACPolicy.Set(context.Background(), rbacpolicy.SetRequest{
+			Project:         env.Project,
+			Environment:     env.Environment,
+			StytchUser:      policy.StytchUser,
+			CustomRoles:     policy.CustomRoles,
+			CustomResources: policy.CustomResources,
+			CustomScopes:    policy.CustomScopes,
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.RBACPolicy.Get(context.Background(), rbacpolicy.GetRequest{
+			Project:     env.Project,
+			Environment: env.Environment,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, policy.StytchUser, resp.Policy.StytchUser)
+		assert.Equal(t, policy.CustomRoles, resp.Policy.CustomRoles)
+		assert.Equal(t, policy.CustomResources, resp.Policy.CustomResources)
+		assert.Equal(t, policy.CustomScopes, resp.Policy.CustomScopes)
+	})
+}
+
+func TestRBACClient_SetPolicy(t *testing.T) {
+	t.Run("B2B policy", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		env := client.DisposableEnvironment(projects.VerticalB2B, environments.EnvironmentTypeTest)
+		policy := getTestB2BPolicy(t, client, env.Project, env.Environment)
+
+		// Act
+		resp, err := client.RBACPolicy.Set(context.Background(), rbacpolicy.SetRequest{
+			Project:         env.Project,
+			Environment:     env.Environment,
+			StytchMember:    policy.StytchMember,
+			StytchAdmin:     policy.StytchAdmin,
+			CustomRoles:     policy.CustomRoles,
+			CustomResources: policy.CustomResources,
+			CustomScopes:    policy.CustomScopes,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, policy.StytchMember, resp.Policy.StytchMember)
+		assert.Equal(t, policy.StytchAdmin, resp.Policy.StytchAdmin)
+		assert.Equal(t, policy.CustomRoles, resp.Policy.CustomRoles)
+		assert.Equal(t, policy.CustomResources, resp.Policy.CustomResources)
+		assert.Equal(t, policy.CustomScopes, resp.Policy.CustomScopes)
+	})
+	t.Run("B2C policy", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		env := client.DisposableEnvironment(projects.VerticalConsumer, environments.EnvironmentTypeTest)
+		policy := getTestB2CPolicy(t, client, env.Project, env.Environment)
+
+		// Act
+		resp, err := client.RBACPolicy.Set(context.Background(), rbacpolicy.SetRequest{
+			Project:         env.Project,
+			Environment:     env.Environment,
+			StytchUser:      policy.StytchUser,
+			CustomRoles:     policy.CustomRoles,
+			CustomResources: policy.CustomResources,
+			CustomScopes:    policy.CustomScopes,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, policy.StytchUser, resp.Policy.StytchUser)
+		assert.Equal(t, policy.CustomRoles, resp.Policy.CustomRoles)
+		assert.Equal(t, policy.CustomResources, resp.Policy.CustomResources)
+		assert.Equal(t, policy.CustomScopes, resp.Policy.CustomScopes)
+	})
+	t.Run("ignore fields irrelevant to vertical", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		env := client.DisposableEnvironment(projects.VerticalConsumer, environments.EnvironmentTypeTest)
+		policy := getTestB2CPolicy(t, client, env.Project, env.Environment)
+
+		// Act
+		resp, err := client.RBACPolicy.Set(context.Background(), rbacpolicy.SetRequest{
+			Project:     env.Project,
+			Environment: env.Environment,
+			StytchUser:  policy.StytchUser,
+			// Set StytchMember, which is irrelevant for Consumer projects.
+			StytchMember:    policy.StytchUser,
+			CustomRoles:     policy.CustomRoles,
+			CustomResources: policy.CustomResources,
+			CustomScopes:    policy.CustomScopes,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, policy.StytchUser, resp.Policy.StytchUser)
+		// StytchMember should be ignored and not set in the response.
+		assert.Nil(t, resp.Policy.StytchMember)
+		assert.Equal(t, policy.CustomRoles, resp.Policy.CustomRoles)
+		assert.Equal(t, policy.CustomResources, resp.Policy.CustomResources)
+		assert.Equal(t, policy.CustomScopes, resp.Policy.CustomScopes)
+	})
+}

--- a/pkg/api/redirecturls.go
+++ b/pkg/api/redirecturls.go
@@ -54,7 +54,6 @@ func (c *RedirectURLsClient) GetAll(
 		nil,
 		nil,
 		&resp)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/models/rbacpolicy/types.go
+++ b/pkg/models/rbacpolicy/types.go
@@ -1,110 +1,114 @@
 package rbacpolicy
 
 type Policy struct {
-	// StytchMember is the default role given to members within the environment
-	// Valid for B2B projects
+	// The following fields are valid for B2B projects only:
+	// StytchMember is the default role given to members within the environment.
 	StytchMember *Role `json:"stytch_member,omitempty"`
-	// StytchAdmin is the role assigned to admins within an organization
-	// Valid for B2B projects
+	// StytchAdmin is the role assigned to admins within an organization.
 	StytchAdmin *Role `json:"stytch_admin,omitempty"`
 	// StytchResources consists of resources created by Stytch that always exist.
 	// This field will be returned in relevant Policy objects but can never be overridden or deleted.
-	// Valid for B2B projects
 	StytchResources []Resource `json:"stytch_resources,omitempty"`
-	// StytchUser is the default role given to users within the environment
-	// Valid for Consumer projects
+
+	// The following field is valid for Consumer projects only:
+	// StytchUser is the default role given to users within the environment.
 	StytchUser *Role `json:"stytch_user,omitempty"`
-	// The following fields are valid for both B2B and Consumer projects
-	// CustomRoles are additional roles that exist within the environment beyond the stytch_member or stytch_admin roles
-	CustomRoles []Role `json:"custom_roles"`
-	// CustomResources are resources that exist within the environment beyond those defined within the stytch_resources
-	CustomResources []Resource `json:"custom_resources"`
-	// CustomScopes are additional scopes that exist within the environment beyond those defined within the stytch_resources
-	CustomScopes []Scope `json:"custom_scopes"`
+
+	// The following fields are valid for both B2B and Consumer projects:
+	// CustomRoles are additional roles that exist within the environment beyond the stytch_member,
+	// stytch_admin, or stytch_user roles.
+	CustomRoles []Role `json:"custom_roles,omitempty"`
+	// CustomResources are resources that exist within the environment beyond those defined within the
+	// stytch_resources.
+	CustomResources []Resource `json:"custom_resources,omitempty"`
+	// CustomScopes are additional scopes that exist within the environment beyond those defined
+	// by default.
+	CustomScopes []Scope `json:"custom_scopes,omitempty"`
 }
 
 type Role struct {
-	// RoleID is a human-readable name that is unique within the environment
+	// RoleID is a human-readable name that is unique within the environment.
 	RoleID string `json:"role_id"`
-	// Description is a description for the role
+	// Description is a description for the role.
 	Description string `json:"description"`
-	// Permissions are the permissions granted to this role for resources within the environment
+	// Permissions are the permissions granted to this role for resources within the environment.
 	Permissions []Permission `json:"permissions"`
 }
 
 type Resource struct {
-	// ResourceID is a human-readable name that is unique within the environment
+	// ResourceID is a human-readable name that is unique within the environment.
 	ResourceID string `json:"resource_id"`
-	// Description is a description for the resource
+	// Description is a description for the resource.
 	Description string `json:"description"`
-	// AvailableActions are the actions that can be granted for this resource
+	// AvailableActions are the actions that can be granted for this resource.
 	AvailableActions []string `json:"available_actions"`
 }
 
 type Scope struct {
-	// Scope is a human-readable name that is unique within the environment
+	// Scope is a human-readable name that is unique within the environment.
 	Scope string `json:"scope"`
-	// Description is a description for the scope
+	// Description is a description for the scope.
 	Description string `json:"description"`
-	// Permissions are the permissions granted to this scope for resources within the environment
+	// Permissions are the permissions granted to this scope for resources within the environment.
 	Permissions []Permission `json:"permissions"`
 }
 
 type Permission struct {
-	// ResourceID is the ID of the resource that the role can perform actions on
+	// ResourceID is the ID of the resource that on which the role can perform actions.
 	ResourceID string `json:"resource_id"`
-	// Actions is an array of actions that the role can perform on the given resource
+	// Actions is an array of actions that the role can perform on the given resource.
 	Actions []string `json:"actions"`
 }
 
 type GetRequest struct {
-	// Project is the project to get the RBAC policy for
+	// Project is the project for which to retrieve the RBAC policy.
 	Project string `json:"-"`
-	// Environment is the environment to get the RBAC policy for
+	// Environment is the environment for which to retrieve the RBAC policy.
 	Environment string `json:"-"`
 }
 
 type GetResponse struct {
-	// StatusCode is the HTTP status code for the request
+	// StatusCode is the HTTP status code for the request.
 	StatusCode int `json:"status_code"`
-	// RequestID is a unique identifier to help with debugging the request
+	// RequestID is a unique identifier to help with debugging the request.
 	RequestID string `json:"request_id"`
-	// Policy is the RBAC policy for the environment
+	// Policy is the RBAC policy for the environment.
 	Policy Policy `json:"policy"`
 }
 
 type SetRequest struct {
-	// Project is the project to set the RBAC policy for
+	// Project is the project for which to set the RBAC policy.
 	Project string `json:"-"`
-	// Environment is the environment to set the RBAC policy for
+	// Environment is the environment for which to set the RBAC policy/
 	Environment string `json:"-"`
-	// StytchMember is the default role given to members within the environment
-	// Valid for B2B projects
-	StytchMember *Role `json:"stytch_member"`
-	// StytchAdmin is the role assigned to admins within an organization
-	// Valid for B2B projects
-	StytchAdmin *Role `json:"stytch_admin"`
-	// StytchResources consists of resources created by Stytch that always exist.
-	// This field will be returned in relevant Policy objects but can never be overridden or deleted.
-	// Valid for B2B projects
-	StytchResources []Resource `json:"stytch_resources"`
-	// StytchUser is the default role given to users within the environment
-	// Valid for Consumer projects
-	StytchUser *Role `json:"stytch_user"`
-	// The following fields are valid for both B2B and Consumer projects
-	// CustomRoles are additional roles that exist within the environment beyond the stytch_member or stytch_admin roles
-	CustomRoles []Role `json:"custom_roles"`
-	// CustomResources are resources that exist within the environment beyond those defined within the stytch_resources
-	CustomResources []Resource `json:"custom_resources"`
-	// CustomScopes are additional scopes that exist within the environment beyond those defined within the stytch_resources
-	CustomScopes []Scope `json:"custom_scopes"`
+
+	// The following fields are valid for B2B projects only:
+	// StytchMember is the default role given to members within the environment.
+	StytchMember *Role `json:"stytch_member,omitempty"`
+	// StytchAdmin is the role assigned to admins within an organization.
+	StytchAdmin *Role `json:"stytch_admin,omitempty"`
+
+	// The following field is valid for Consumer projects only:
+	// StytchUser is the default role given to users within the environment.
+	StytchUser *Role `json:"stytch_user,omitempty"`
+
+	// The following fields are valid for both B2B and Consumer projects:
+	// CustomRoles are additional roles that exist within the environment beyond the stytch_member,
+	// stytch_admin, or stytch_user roles.
+	CustomRoles []Role `json:"custom_roles,omitempty"`
+	// CustomResources are resources that exist within the environment beyond those defined within the
+	// stytch_resources.
+	CustomResources []Resource `json:"custom_resources,omitempty"`
+	// CustomScopes are additional scopes that exist within the environment beyond those defined
+	// by default.
+	CustomScopes []Scope `json:"custom_scopes,omitempty"`
 }
 
 type SetResponse struct {
-	// StatusCode is the HTTP status code for the request
+	// StatusCode is the HTTP status code for the request.
 	StatusCode int `json:"status_code"`
-	// RequestID is a unique identifier to help with debugging the request
+	// RequestID is a unique identifier to help with debugging the request.
 	RequestID string `json:"request_id"`
-	// Policy is the RBAC policy for the environment
+	// Policy is the RBAC policy for the environment.
 	Policy Policy `json:"policy"`
 }


### PR DESCRIPTION
## Description

Adds support for both B2B and Consumer RBAC policy.
1. Removes `StytchResources` from `SetRequest` since the field is not modifiable / ignored in the request. I will also remove it from the PWA protos in a following PR.
2. Adds tests for both B2B and Consumer RBAC policy.

## Testing

- [x] Added unit tests, existing tests pass.