### PR TITLE
[V3] Proper URL query escape for URL when passing the redirect url in the URL

### DIFF
--- a/pkg/api/redirecturls.go
+++ b/pkg/api/redirecturls.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/stytchauth/stytch-management-go/v3/pkg/api/internal"
 	"github.com/stytchauth/stytch-management-go/v3/pkg/models/redirecturls"
@@ -54,7 +55,6 @@ func (c *RedirectURLsClient) GetAll(
 		nil,
 		nil,
 		&resp)
-
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (c *RedirectURLsClient) Get(
 	err := c.client.NewRequest(
 		ctx,
 		"GET",
-		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/redirect_urls?url=%s", body.Project, body.Environment, body.URL),
+		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/redirect_urls?url=%s", body.Project, body.Environment, url.QueryEscape(body.URL)),
 		nil,
 		nil,
 		&res)
@@ -94,7 +94,7 @@ func (c *RedirectURLsClient) Update(
 	err = c.client.NewRequest(
 		ctx,
 		"PUT",
-		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/redirect_urls?url=%s", body.Project, body.Environment, body.URL),
+		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/redirect_urls?url=%s", body.Project, body.Environment, url.QueryEscape(body.URL)),
 		nil,
 		jsonBody,
 		&res)
@@ -113,7 +113,7 @@ func (c *RedirectURLsClient) Delete(
 	err := c.client.NewRequest(
 		ctx,
 		"DELETE",
-		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/redirect_urls?url=%s", body.Project, body.Environment, body.URL),
+		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/redirect_urls?url=%s", body.Project, body.Environment, url.QueryEscape(body.URL)),
 		nil,
 		nil,
 		&res)


### PR DESCRIPTION
## Description 

Based on https://github.com/stytchauth/stytch-management-go/pull/80 but for v3

## Tests

Added a test for GET