### PR TITLE
[V3] EmailTemplates endpoint and tests

### DIFF
--- a/pkg/api/emailtemplates.go
+++ b/pkg/api/emailtemplates.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/stytchauth/stytch-management-go/v3/pkg/api/internal"
 	"github.com/stytchauth/stytch-management-go/v3/pkg/models/emailtemplates"
@@ -17,7 +18,7 @@ func newEmailTemplatesClient(c *internal.Client) *EmailTemplatesClient {
 	return &EmailTemplatesClient{client: c}
 }
 
-// GetAll retrieves all email templates for a project
+// GetAll retrieves all email templates for a project.
 func (c *EmailTemplatesClient) GetAll(
 	ctx context.Context,
 	body emailtemplates.GetAllRequest,
@@ -25,16 +26,18 @@ func (c *EmailTemplatesClient) GetAll(
 	var resp emailtemplates.GetAllResponse
 	err := c.client.NewRequest(
 		ctx,
-		"GET",
+		http.MethodGet,
 		fmt.Sprintf("/pwa/v3/projects/%s/email_templates", body.Project),
 		nil,
 		nil,
 		&resp)
-
-	return &resp, err
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }
 
-// Get retrieves an email template for a project
+// Get retrieves an email template for a project.
 func (c *EmailTemplatesClient) Get(
 	ctx context.Context,
 	body emailtemplates.GetRequest,
@@ -42,16 +45,18 @@ func (c *EmailTemplatesClient) Get(
 	var resp emailtemplates.GetResponse
 	err := c.client.NewRequest(
 		ctx,
-		"GET",
+		http.MethodGet,
 		fmt.Sprintf("/pwa/v3/projects/%s/email_templates/%s", body.Project, body.TemplateID),
 		nil,
 		nil,
 		&resp)
-
-	return &resp, err
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }
 
-// Create creates an email template for a project
+// Create creates an email template for a project.
 func (c *EmailTemplatesClient) Create(
 	ctx context.Context,
 	body emailtemplates.CreateRequest,
@@ -61,34 +66,40 @@ func (c *EmailTemplatesClient) Create(
 		return nil, err
 	}
 
-	var res emailtemplates.CreateResponse
+	var resp emailtemplates.CreateResponse
 	err = c.client.NewRequest(
 		ctx,
-		"POST",
+		http.MethodPost,
 		fmt.Sprintf("/pwa/v3/projects/%s/email_templates", body.Project),
 		nil,
 		jsonBody,
-		&res)
-	return &res, err
+		&resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }
 
-// Delete deletes an email template for a project
+// Delete deletes an email template for a project.
 func (c *EmailTemplatesClient) Delete(
 	ctx context.Context,
 	body emailtemplates.DeleteRequest,
 ) (*emailtemplates.DeleteResponse, error) {
-	var res emailtemplates.DeleteResponse
+	var resp emailtemplates.DeleteResponse
 	err := c.client.NewRequest(
 		ctx,
-		"DELETE",
+		http.MethodDelete,
 		fmt.Sprintf("/pwa/v3/projects/%s/email_templates/%s", body.Project, body.TemplateID),
 		nil,
 		nil,
-		&res)
-	return &res, err
+		&resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }
 
-// Update updates an email template for a project
+// Update updates an email template for a project.
 func (c *EmailTemplatesClient) Update(
 	ctx context.Context,
 	body emailtemplates.UpdateRequest,
@@ -98,13 +109,16 @@ func (c *EmailTemplatesClient) Update(
 		return nil, err
 	}
 
-	var res emailtemplates.UpdateResponse
+	var resp emailtemplates.UpdateResponse
 	err = c.client.NewRequest(
 		ctx,
-		"PUT",
+		http.MethodPut,
 		fmt.Sprintf("/pwa/v3/projects/%s/email_templates/%s", body.Project, body.TemplateID),
 		nil,
 		jsonBody,
-		&res)
-	return &res, err
+		&resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }

--- a/pkg/api/emailtemplates_test.go
+++ b/pkg/api/emailtemplates_test.go
@@ -1,0 +1,275 @@
+package api_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/emailtemplates"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/models/projects"
+)
+
+func randomID() string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return fmt.Sprintf("test-template-%d", r.Intn(1000000))
+}
+
+func makeTestPrebuiltTemplate(templateID string) emailtemplates.PrebuiltCustomization {
+	return emailtemplates.PrebuiltCustomization{
+		ButtonBorderRadius: ptr(float32(5.0)),
+		ButtonColor:        ptr("#007BFF"),
+		ButtonTextColor:    ptr("#FFFFFF"),
+		FontFamily:         ptr(emailtemplates.FontFamilyArial),
+		TextAlignment:      ptr(emailtemplates.TextAlignmentCenter),
+	}
+}
+
+func senderInformation() *emailtemplates.SenderInformation {
+	return &emailtemplates.SenderInformation{
+		FromLocalPart:    ptr("noreply"),
+		FromName:         ptr("No Reply"),
+		ReplyToLocalPart: ptr("support"),
+		ReplyToName:      ptr("Support Team"),
+	}
+}
+
+// NOTE: Custom HTML Templates can only be managed in
+// projects with verified domains, so they are excluded
+// from these tests.
+
+func TestEmailTemplatesClient_Create(t *testing.T) {
+	t.Run("create prebuilt template", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+		templateID := randomID()
+		template := makeTestPrebuiltTemplate(templateID)
+
+		// Act
+		resp, err := client.EmailTemplates.Create(ctx, emailtemplates.CreateRequest{
+			Project:               project.Project,
+			TemplateID:            templateID,
+			Name:                  ptr("Test Prebuilt Template"),
+			SenderInformation:     senderInformation(),
+			PrebuiltCustomization: &template,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, templateID, resp.EmailTemplate.TemplateID)
+		assert.Equal(t, "Test Prebuilt Template", *resp.EmailTemplate.Name)
+		assert.NotNil(t, resp.EmailTemplate.SenderInformation)
+		assert.NotNil(t, resp.EmailTemplate.PrebuiltCustomization)
+		assert.Nil(t, resp.EmailTemplate.CustomHTMLCustomization)
+	})
+}
+
+func TestEmailTemplatesClient_Get(t *testing.T) {
+	t.Run("get existing prebuilt template", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+		templateID := randomID()
+		template := makeTestPrebuiltTemplate(templateID)
+
+		// Create template first
+		createResp, err := client.EmailTemplates.Create(ctx, emailtemplates.CreateRequest{
+			Project:               project.Project,
+			TemplateID:            templateID,
+			Name:                  ptr("Test Prebuilt Template"),
+			SenderInformation:     senderInformation(),
+			PrebuiltCustomization: &template,
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.EmailTemplates.Get(ctx, emailtemplates.GetRequest{
+			Project:    project.Project,
+			TemplateID: templateID,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, createResp.EmailTemplate.TemplateID, resp.EmailTemplate.TemplateID)
+		assert.Equal(t, createResp.EmailTemplate.Name, resp.EmailTemplate.Name)
+		assert.NotNil(t, resp.EmailTemplate.PrebuiltCustomization)
+		assert.Nil(t, resp.EmailTemplate.CustomHTMLCustomization)
+	})
+
+	t.Run("get non-existent template", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.EmailTemplates.Get(ctx, emailtemplates.GetRequest{
+			Project:    project.Project,
+			TemplateID: "non-existent-template",
+		})
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestEmailTemplatesClient_GetAll(t *testing.T) {
+	t.Run("get all templates", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Create multiple templates
+		template1ID := randomID()
+		template2ID := randomID()
+
+		template1 := makeTestPrebuiltTemplate(template1ID)
+		template2 := makeTestPrebuiltTemplate(template2ID)
+
+		_, err := client.EmailTemplates.Create(ctx, emailtemplates.CreateRequest{
+			Project:               project.Project,
+			TemplateID:            template1ID,
+			Name:                  ptr("Test Prebuilt Template"),
+			SenderInformation:     senderInformation(),
+			PrebuiltCustomization: &template1,
+		})
+		require.NoError(t, err)
+
+		_, err = client.EmailTemplates.Create(ctx, emailtemplates.CreateRequest{
+			Project:               project.Project,
+			TemplateID:            template2ID,
+			Name:                  ptr("Test Prebuilt Template 2"),
+			SenderInformation:     senderInformation(),
+			PrebuiltCustomization: &template2,
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.EmailTemplates.GetAll(ctx, emailtemplates.GetAllRequest{
+			Project: project.Project,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, len(resp.EmailTemplates), 2)
+
+		// Check that both templates are present
+		templateIDs := make(map[string]bool)
+		for _, template := range resp.EmailTemplates {
+			templateIDs[template.TemplateID] = true
+		}
+		assert.Contains(t, templateIDs, template1ID)
+		assert.Contains(t, templateIDs, template2ID)
+	})
+}
+
+func TestEmailTemplatesClient_Update(t *testing.T) {
+	t.Run("update prebuilt template", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+		templateID := randomID()
+		template := makeTestPrebuiltTemplate(templateID)
+
+		// Create template first
+		_, err := client.EmailTemplates.Create(ctx, emailtemplates.CreateRequest{
+			Project:               project.Project,
+			TemplateID:            templateID,
+			Name:                  ptr("Test Prebuilt Template"),
+			SenderInformation:     senderInformation(),
+			PrebuiltCustomization: &template,
+		})
+		require.NoError(t, err)
+
+		// Act - update the template
+		newName := "Updated Prebuilt Template"
+		updatedTemplate := emailtemplates.PrebuiltCustomization{
+			ButtonBorderRadius: ptr(float32(10.0)),
+			ButtonColor:        ptr("#FF0000"),
+			ButtonTextColor:    ptr("#000000"),
+			FontFamily:         ptr(emailtemplates.FontFamilyHelvetica),
+			TextAlignment:      ptr(emailtemplates.TextAlignmentLeft),
+		}
+
+		resp, err := client.EmailTemplates.Update(ctx, emailtemplates.UpdateRequest{
+			Project:               project.Project,
+			TemplateID:            templateID,
+			Name:                  &newName,
+			PrebuiltCustomization: &updatedTemplate,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, templateID, resp.EmailTemplate.TemplateID)
+		assert.Equal(t, newName, *resp.EmailTemplate.Name)
+		assert.NotNil(t, resp.EmailTemplate.PrebuiltCustomization)
+		assert.Equal(t, updatedTemplate, *resp.EmailTemplate.PrebuiltCustomization)
+		assert.Nil(t, resp.EmailTemplate.CustomHTMLCustomization)
+	})
+
+	t.Run("update non-existent template", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		newName := "Non-existent Template"
+		resp, err := client.EmailTemplates.Update(ctx, emailtemplates.UpdateRequest{
+			Project:    project.Project,
+			TemplateID: "non-existent-template",
+			Name:       &newName,
+		})
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestEmailTemplatesClient_Delete(t *testing.T) {
+	t.Run("delete existing template", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+		templateID := randomID()
+		template := makeTestPrebuiltTemplate(templateID)
+
+		// Create template first
+		_, err := client.EmailTemplates.Create(ctx, emailtemplates.CreateRequest{
+			Project:               project.Project,
+			TemplateID:            templateID,
+			Name:                  ptr("Test Prebuilt Template"),
+			SenderInformation:     senderInformation(),
+			PrebuiltCustomization: &template,
+		})
+		require.NoError(t, err)
+
+		// Act
+		resp, err := client.EmailTemplates.Delete(ctx, emailtemplates.DeleteRequest{
+			Project:    project.Project,
+			TemplateID: templateID,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify template is deleted by trying to get it
+		_, err = client.EmailTemplates.Get(ctx, emailtemplates.GetRequest{
+			Project:    project.Project,
+			TemplateID: templateID,
+		})
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Description

- Update emailtemplates.go -> Proper error handling, use http constants
- Add tests
  - Note: no tests for html customization since that requires verified domains, and we're using disposable projects.

## Testing

- [x] New tests pass