### PR TITLE
[v3] Check for missing resource IDs in Get requests

### DIFF
--- a/pkg/api/emailtemplates.go
+++ b/pkg/api/emailtemplates.go
@@ -18,44 +18,6 @@ func newEmailTemplatesClient(c *internal.Client) *EmailTemplatesClient {
 	return &EmailTemplatesClient{client: c}
 }
 
-// GetAll retrieves all email templates for a project.
-func (c *EmailTemplatesClient) GetAll(
-	ctx context.Context,
-	body emailtemplates.GetAllRequest,
-) (*emailtemplates.GetAllResponse, error) {
-	var resp emailtemplates.GetAllResponse
-	err := c.client.NewRequest(
-		ctx,
-		http.MethodGet,
-		fmt.Sprintf("/pwa/v3/projects/%s/email_templates", body.Project),
-		nil,
-		nil,
-		&resp)
-	if err != nil {
-		return nil, err
-	}
-	return &resp, nil
-}
-
-// Get retrieves an email template for a project.
-func (c *EmailTemplatesClient) Get(
-	ctx context.Context,
-	body emailtemplates.GetRequest,
-) (*emailtemplates.GetResponse, error) {
-	var resp emailtemplates.GetResponse
-	err := c.client.NewRequest(
-		ctx,
-		http.MethodGet,
-		fmt.Sprintf("/pwa/v3/projects/%s/email_templates/%s", body.Project, body.TemplateID),
-		nil,
-		nil,
-		&resp)
-	if err != nil {
-		return nil, err
-	}
-	return &resp, nil
-}
-
 // Create creates an email template for a project.
 func (c *EmailTemplatesClient) Create(
 	ctx context.Context,
@@ -80,16 +42,38 @@ func (c *EmailTemplatesClient) Create(
 	return &resp, nil
 }
 
-// Delete deletes an email template for a project.
-func (c *EmailTemplatesClient) Delete(
+// Get retrieves an email template for a project.
+func (c *EmailTemplatesClient) Get(
 	ctx context.Context,
-	body emailtemplates.DeleteRequest,
-) (*emailtemplates.DeleteResponse, error) {
-	var resp emailtemplates.DeleteResponse
+	body emailtemplates.GetRequest,
+) (*emailtemplates.GetResponse, error) {
+	if body.TemplateID == "" {
+		return nil, fmt.Errorf("missing template ID")
+	}
+	var resp emailtemplates.GetResponse
 	err := c.client.NewRequest(
 		ctx,
-		http.MethodDelete,
+		http.MethodGet,
 		fmt.Sprintf("/pwa/v3/projects/%s/email_templates/%s", body.Project, body.TemplateID),
+		nil,
+		nil,
+		&resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetAll retrieves all email templates for a project.
+func (c *EmailTemplatesClient) GetAll(
+	ctx context.Context,
+	body emailtemplates.GetAllRequest,
+) (*emailtemplates.GetAllResponse, error) {
+	var resp emailtemplates.GetAllResponse
+	err := c.client.NewRequest(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("/pwa/v3/projects/%s/email_templates", body.Project),
 		nil,
 		nil,
 		&resp)
@@ -116,6 +100,25 @@ func (c *EmailTemplatesClient) Update(
 		fmt.Sprintf("/pwa/v3/projects/%s/email_templates/%s", body.Project, body.TemplateID),
 		nil,
 		jsonBody,
+		&resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Delete deletes an email template for a project.
+func (c *EmailTemplatesClient) Delete(
+	ctx context.Context,
+	body emailtemplates.DeleteRequest,
+) (*emailtemplates.DeleteResponse, error) {
+	var resp emailtemplates.DeleteResponse
+	err := c.client.NewRequest(
+		ctx,
+		http.MethodDelete,
+		fmt.Sprintf("/pwa/v3/projects/%s/email_templates/%s", body.Project, body.TemplateID),
+		nil,
+		nil,
 		&resp)
 	if err != nil {
 		return nil, err

--- a/pkg/api/emailtemplates_test.go
+++ b/pkg/api/emailtemplates_test.go
@@ -101,7 +101,6 @@ func TestEmailTemplatesClient_Get(t *testing.T) {
 		assert.NotNil(t, resp.EmailTemplate.PrebuiltCustomization)
 		assert.Nil(t, resp.EmailTemplate.CustomHTMLCustomization)
 	})
-
 	t.Run("get non-existent template", func(t *testing.T) {
 		// Arrange
 		client := NewTestClient(t)
@@ -116,6 +115,22 @@ func TestEmailTemplatesClient_Get(t *testing.T) {
 
 		// Assert
 		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+	t.Run("missing template ID", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.EmailTemplates.Get(ctx, emailtemplates.GetRequest{
+			Project: project.Project,
+			// TemplateID is intentionally omitted.
+		})
+
+		// Assert
+		assert.ErrorContains(t, err, "template ID")
 		assert.Nil(t, resp)
 	})
 }

--- a/pkg/api/environments.go
+++ b/pkg/api/environments.go
@@ -49,6 +49,9 @@ func (c *EnvironmentsClient) Get(
 	ctx context.Context,
 	body environments.GetRequest,
 ) (*environments.GetResponse, error) {
+	if body.Environment == "" {
+		return nil, fmt.Errorf("missing environment")
+	}
 	var resp environments.GetResponse
 	err := c.client.NewRequest(
 		ctx,

--- a/pkg/api/environments_test.go
+++ b/pkg/api/environments_test.go
@@ -75,6 +75,22 @@ func Test_EnvironmentsGet(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, resp)
 	})
+	t.Run("missing environment", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalB2B)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.Environments.Get(ctx, environments.GetRequest{
+			Project: project.Project,
+			// Environment is intentionally omitted.
+		})
+
+		// Assert
+		assert.ErrorContains(t, err, "environment")
+		assert.Nil(t, resp)
+	})
 }
 
 func hasEnvironment(environments []environments.Environment, target environments.Environment) bool {

--- a/pkg/api/projects.go
+++ b/pkg/api/projects.go
@@ -43,6 +43,9 @@ func (c *ProjectsClient) Get(
 	ctx context.Context,
 	body projects.GetRequest,
 ) (*projects.GetResponse, error) {
+	if body.Project == "" {
+		return nil, fmt.Errorf("missing project")
+	}
 	var res projects.GetResponse
 	err := c.client.NewRequest(ctx, http.MethodGet, fmt.Sprintf("/pwa/v3/projects/%s", body.Project), nil, nil, &res)
 	if err != nil {
@@ -54,7 +57,7 @@ func (c *ProjectsClient) Get(
 // GetAll retrieves all projects in a workspace.
 func (c *ProjectsClient) GetAll(
 	ctx context.Context,
-	body projects.GetAllRequest,
+	_ projects.GetAllRequest,
 ) (*projects.GetAllResponse, error) {
 	var res projects.GetAllResponse
 	err := c.client.NewRequest(ctx, http.MethodGet, "/pwa/v3/projects", nil, nil, &res)

--- a/pkg/api/projects_test.go
+++ b/pkg/api/projects_test.go
@@ -65,6 +65,20 @@ func Test_ProjectsGet(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, resp)
 	})
+	t.Run("missing project", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.Projects.Get(ctx, projects.GetRequest{
+			// Project is intentionally omitted.
+		})
+
+		// Assert
+		assert.ErrorContains(t, err, "project")
+		assert.Nil(t, resp)
+	})
 }
 
 func hasProject(projects []projects.Project, target projects.Project) bool {

--- a/pkg/api/secrets.go
+++ b/pkg/api/secrets.go
@@ -17,42 +17,8 @@ func newSecretsClient(c *internal.Client) *SecretsClient {
 	return &SecretsClient{client: c}
 }
 
-// Get retrieves a secret for a project
-func (c *SecretsClient) Get(ctx context.Context, body secrets.GetSecretRequest) (*secrets.GetSecretResponse, error) {
-	var resp secrets.GetSecretResponse
-	err := c.client.NewRequest(
-		ctx,
-		http.MethodGet,
-		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/secrets/%s", body.Project, body.Environment, body.SecretID),
-		nil,
-		nil,
-		&resp,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return &resp, nil
-}
-
-// GetAll retrieves all secrets for a project
-func (c *SecretsClient) GetAll(ctx context.Context, body secrets.GetAllSecretsRequest) (*secrets.GetAllSecretsResponse, error) {
-	var resp secrets.GetAllSecretsResponse
-	err := c.client.NewRequest(
-		ctx,
-		http.MethodGet,
-		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/secrets", body.Project, body.Environment),
-		nil,
-		nil,
-		&resp,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return &resp, nil
-}
-
-// Create creates a secret for a project. The response has the secret value, which
-// will not be exposed in future Get requests
+// Create creates a secret for a project. The response contains the full secret value, which
+// will not be exposed in future Get requests.
 func (c *SecretsClient) Create(ctx context.Context, body secrets.CreateSecretRequest) (*secrets.CreateSecretResponse, error) {
 	var resp secrets.CreateSecretResponse
 	err := c.client.NewRequest(
@@ -69,7 +35,44 @@ func (c *SecretsClient) Create(ctx context.Context, body secrets.CreateSecretReq
 	return &resp, nil
 }
 
-// Delete deletes a secret for a project
+// Get retrieves a secret for a project.
+func (c *SecretsClient) Get(ctx context.Context, body secrets.GetSecretRequest) (*secrets.GetSecretResponse, error) {
+	if body.SecretID == "" {
+		return nil, fmt.Errorf("missing secret ID")
+	}
+	var resp secrets.GetSecretResponse
+	err := c.client.NewRequest(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/secrets/%s", body.Project, body.Environment, body.SecretID),
+		nil,
+		nil,
+		&resp,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetAll retrieves all secrets for a project.
+func (c *SecretsClient) GetAll(ctx context.Context, body secrets.GetAllSecretsRequest) (*secrets.GetAllSecretsResponse, error) {
+	var resp secrets.GetAllSecretsResponse
+	err := c.client.NewRequest(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("/pwa/v3/projects/%s/environments/%s/secrets", body.Project, body.Environment),
+		nil,
+		nil,
+		&resp,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Delete deletes a secret for a project.
 func (c *SecretsClient) Delete(ctx context.Context, body secrets.DeleteSecretRequest) (*secrets.DeleteSecretResponse, error) {
 	var resp secrets.DeleteSecretResponse
 	err := c.client.NewRequest(

--- a/pkg/api/secrets.go
+++ b/pkg/api/secrets.go
@@ -17,7 +17,7 @@ func newSecretsClient(c *internal.Client) *SecretsClient {
 	return &SecretsClient{client: c}
 }
 
-// Create creates a secret for a project. The response contains the full secret value, which
+// Create creates a secret for an environment. The response contains the full secret value, which
 // will not be exposed in future Get requests.
 func (c *SecretsClient) Create(ctx context.Context, body secrets.CreateSecretRequest) (*secrets.CreateSecretResponse, error) {
 	var resp secrets.CreateSecretResponse
@@ -35,7 +35,7 @@ func (c *SecretsClient) Create(ctx context.Context, body secrets.CreateSecretReq
 	return &resp, nil
 }
 
-// Get retrieves a secret for a project.
+// Get retrieves a secret for an environment.
 func (c *SecretsClient) Get(ctx context.Context, body secrets.GetSecretRequest) (*secrets.GetSecretResponse, error) {
 	if body.SecretID == "" {
 		return nil, fmt.Errorf("missing secret ID")
@@ -55,7 +55,7 @@ func (c *SecretsClient) Get(ctx context.Context, body secrets.GetSecretRequest) 
 	return &resp, nil
 }
 
-// GetAll retrieves all secrets for a project.
+// GetAll retrieves all secrets for an environment.
 func (c *SecretsClient) GetAll(ctx context.Context, body secrets.GetAllSecretsRequest) (*secrets.GetAllSecretsResponse, error) {
 	var resp secrets.GetAllSecretsResponse
 	err := c.client.NewRequest(
@@ -72,7 +72,7 @@ func (c *SecretsClient) GetAll(ctx context.Context, body secrets.GetAllSecretsRe
 	return &resp, nil
 }
 
-// Delete deletes a secret for a project.
+// Delete deletes a secret for an environment.
 func (c *SecretsClient) Delete(ctx context.Context, body secrets.DeleteSecretRequest) (*secrets.DeleteSecretResponse, error) {
 	var resp secrets.DeleteSecretResponse
 	err := c.client.NewRequest(

--- a/pkg/api/secrets_test.go
+++ b/pkg/api/secrets_test.go
@@ -61,7 +61,6 @@ func TestSecretsClient_GetSecret(t *testing.T) {
 		assert.Equal(t, createResp.CreatedSecret.Secret[len(createResp.CreatedSecret.Secret)-4:], resp.Secret.LastFour)
 		assert.Equal(t, createResp.CreatedSecret.CreatedAt, resp.Secret.CreatedAt)
 	})
-
 	t.Run("secret does not exist", func(t *testing.T) {
 		// Arrange
 		client := NewTestClient(t)
@@ -77,6 +76,23 @@ func TestSecretsClient_GetSecret(t *testing.T) {
 
 		// Assert
 		assert.Error(t, err)
+		assert.Nil(t, resp)
+	})
+	t.Run("missing secret ID", func(t *testing.T) {
+		// Arrange
+		client := NewTestClient(t)
+		project := client.DisposableProject(projects.VerticalConsumer)
+		ctx := context.Background()
+
+		// Act
+		resp, err := client.Secrets.Get(ctx, secrets.GetSecretRequest{
+			Project:     project.Project,
+			Environment: TestEnvironment,
+			// SecretID is intentionally omitted.
+		})
+
+		// Assert
+		assert.ErrorContains(t, err, "secret ID")
 		assert.Nil(t, resp)
 	})
 }


### PR DESCRIPTION
## Description

See title. This fixes the issue for:
* Email Templates
* Environments
* Projects
* Secrets

There are two resources left that I will tackle later (Public Tokens and Trusted Token Profiles).

## Testing

- [x] Added new unit tests.