### PR TITLE
[v3] Include request IDs on error responses for 404s

### DIFF
--- a/pkg/api/environments_test.go
+++ b/pkg/api/environments_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stytchauth/stytch-management-go/v3/pkg/models/environments"
 	"github.com/stytchauth/stytch-management-go/v3/pkg/models/projects"
+	"github.com/stytchauth/stytch-management-go/v3/pkg/stytcherror"
 )
 
 func Test_EnvironmentsCreate(t *testing.T) {
@@ -143,6 +144,13 @@ func Test_EnvironmentsGet(t *testing.T) {
 		// Assert
 		assert.Error(t, err)
 		assert.Nil(t, resp)
+
+		// Check that the error is well-formatted.
+		var stytchErr stytcherror.Error
+		assert.ErrorAs(t, err, &stytchErr)
+		assert.NotEmpty(t, stytchErr.RequestID)
+		assert.Equal(t, 404, stytchErr.StatusCode)
+		assert.Contains(t, stytchErr.ErrorType, "not_found")
 	})
 	t.Run("missing environment", func(t *testing.T) {
 		// Arrange

--- a/pkg/api/internal/stytch.go
+++ b/pkg/api/internal/stytch.go
@@ -126,7 +126,14 @@ func (c *Client) RawRequest(
 		return io.ReadAll(res.Body)
 	}
 
+	// Attempt to unmarshal the response body into Stytch error format.
+	var stytchErr stytcherror.Error
+	if json.NewDecoder(res.Body).Decode(&stytchErr) == nil {
+		return nil, stytchErr
+	}
+
 	if res.StatusCode == 404 {
+		// Fallback if the error cannot be unmarshalled.
 		err := stytcherror.Error{
 			StatusCode:   res.StatusCode,
 			ErrorMessage: "Not found.",
@@ -134,11 +141,5 @@ func (c *Client) RawRequest(
 		return nil, err
 	}
 
-	// Attempt to unmarshal into Stytch error format
-	var stytchErr stytcherror.Error
-	if err = json.NewDecoder(res.Body).Decode(&stytchErr); err != nil {
-		return nil, fmt.Errorf("error decoding http request: %w", err)
-	}
-	stytchErr.StatusCode = res.StatusCode
-	return nil, stytchErr
+	return nil, fmt.Errorf("error decoding http response: %w", err)
 }


### PR DESCRIPTION
## Description

See title. This was the legacy behavior for v1 as well. 404s now include request IDs and other stytcherror fields.

## Testing

- [X] Added unit test.