### PR TITLE
[V3] Add missing CanJitProvision to trusted token profile struct

### DIFF
--- a/pkg/api/trustedtokenprofiles_test.go
+++ b/pkg/api/trustedtokenprofiles_test.go
@@ -55,6 +55,7 @@ func TestTrustedTokenProfilesClient_Create(t *testing.T) {
 		assert.Equal(t, testJWKSURL, resp.TrustedTokenProfile.JwksURL)
 		assert.Equal(t, "jwk", resp.TrustedTokenProfile.PublicKeyType)
 		assert.NotEmpty(t, resp.TrustedTokenProfile.ID)
+		assert.True(t, resp.TrustedTokenProfile.CanJITProvision)
 	})
 
 	t.Run("create with PEM files", func(t *testing.T) {
@@ -83,6 +84,7 @@ func TestTrustedTokenProfilesClient_Create(t *testing.T) {
 		assert.Equal(t, "test-issuer-pem", resp.TrustedTokenProfile.Issuer)
 		assert.Equal(t, "pem", resp.TrustedTokenProfile.PublicKeyType)
 		assert.NotEmpty(t, resp.TrustedTokenProfile.ID)
+		assert.False(t, resp.TrustedTokenProfile.CanJITProvision)
 		assert.Len(t, resp.TrustedTokenProfile.PEMFiles, 1)
 	})
 }

--- a/pkg/models/trustedtokenprofiles/types.go
+++ b/pkg/models/trustedtokenprofiles/types.go
@@ -17,6 +17,8 @@ type TrustedTokenProfile struct {
 	PEMFiles []PEMFile `json:"pem_files"`
 	// PublicKeyType is the type of public key.
 	PublicKeyType string `json:"public_key_type"`
+	// CanJITProvision indicates whether the trusted token profile can be provisioned JIT.
+	CanJITProvision bool `json:"can_jit_provision"`
 }
 
 type PEMFile struct {


### PR DESCRIPTION
## Description

See title

## Testing

Added it to the existing unit tests, which pass.