### PR TITLE
[v3] Support project creation with slug

### DIFF
--- a/pkg/api/projects_test.go
+++ b/pkg/api/projects_test.go
@@ -17,8 +17,9 @@ func Test_ProjectsCreate(t *testing.T) {
 
 		// Act
 		resp, err := client.Projects.Create(ctx, projects.CreateRequest{
-			Name:     "Test Project",
-			Vertical: projects.VerticalB2B,
+			Name:        "Test Project",
+			Vertical:    projects.VerticalB2B,
+			ProjectSlug: "custom-slug",
 		})
 		t.Cleanup(func() {
 			_, err := client.Projects.Delete(ctx, projects.DeleteRequest{
@@ -31,6 +32,7 @@ func Test_ProjectsCreate(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "Test Project", resp.Project.Name)
 		assert.Equal(t, projects.VerticalB2B, resp.Project.Vertical)
+		assert.Equal(t, "custom-slug", resp.Project.ProjectSlug)
 	})
 }
 

--- a/pkg/api/projects_test.go
+++ b/pkg/api/projects_test.go
@@ -16,10 +16,11 @@ func Test_ProjectsCreate(t *testing.T) {
 		ctx := context.Background()
 
 		// Act
+		slug := "custom-slug"
 		resp, err := client.Projects.Create(ctx, projects.CreateRequest{
 			Name:        "Test Project",
 			Vertical:    projects.VerticalB2B,
-			ProjectSlug: "custom-slug",
+			ProjectSlug: &slug,
 		})
 		t.Cleanup(func() {
 			_, err := client.Projects.Delete(ctx, projects.DeleteRequest{
@@ -32,7 +33,7 @@ func Test_ProjectsCreate(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "Test Project", resp.Project.Name)
 		assert.Equal(t, projects.VerticalB2B, resp.Project.Vertical)
-		assert.Equal(t, "custom-slug", resp.Project.ProjectSlug)
+		assert.Equal(t, slug, resp.Project.ProjectSlug)
 	})
 }
 

--- a/pkg/models/projects/types.go
+++ b/pkg/models/projects/types.go
@@ -33,6 +33,9 @@ type CreateRequest struct {
 	Name string `json:"name"`
 	// Vertical is the project's vertical.
 	Vertical Vertical `json:"vertical"`
+	// ProjectSlug is the immutable unique identifier (slug) of the project, and cannot be changed
+	// after the project is created. If not provided, a slug will be generated.
+	ProjectSlug string `json:"project_slug"`
 }
 
 type CreateResponse struct {

--- a/pkg/models/projects/types.go
+++ b/pkg/models/projects/types.go
@@ -35,7 +35,7 @@ type CreateRequest struct {
 	Vertical Vertical `json:"vertical"`
 	// ProjectSlug is the immutable unique identifier (slug) of the project, and cannot be changed
 	// after the project is created. If not provided, a slug will be generated.
-	ProjectSlug string `json:"project_slug"`
+	ProjectSlug *string `json:"project_slug"`
 }
 
 type CreateResponse struct {


### PR DESCRIPTION
## Description

See title. Sets the project slug with custom user-provided value  on creation.

## Testing

- [x] Updated unit test.