### PR TITLE
[v3] Support environment creation with slug

### DIFF
--- a/pkg/api/environments_test.go
+++ b/pkg/api/environments_test.go
@@ -19,11 +19,13 @@ func Test_EnvironmentsCreate(t *testing.T) {
 		ctx := context.Background()
 
 		// Act
+		slug := "custom-slug"
 		zeroDowntimeSessionMigrationURL := "https://example.com/migration"
 		resp, err := client.Environments.Create(ctx, environments.CreateRequest{
 			ProjectSlug:                     project.ProjectSlug,
 			Name:                            "Test Environment",
 			Type:                            environments.EnvironmentTypeTest,
+			EnvironmentSlug:                 &slug,
 			CrossOrgPasswordsEnabled:        ptr(true),
 			UserImpersonationEnabled:        ptr(true),
 			ZeroDowntimeSessionMigrationURL: ptr(zeroDowntimeSessionMigrationURL),
@@ -40,6 +42,7 @@ func Test_EnvironmentsCreate(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "Test Environment", resp.Environment.Name)
 		assert.Equal(t, environments.EnvironmentTypeTest, resp.Environment.Type)
+		assert.Equal(t, slug, resp.Environment.EnvironmentSlug)
 		assert.True(t, resp.Environment.CrossOrgPasswordsEnabled)
 		assert.True(t, resp.Environment.UserImpersonationEnabled)
 		assert.Equal(t, zeroDowntimeSessionMigrationURL, resp.Environment.ZeroDowntimeSessionMigrationURL)

--- a/pkg/models/environments/types.go
+++ b/pkg/models/environments/types.go
@@ -72,6 +72,9 @@ type CreateRequest struct {
 	Name string `json:"name"`
 	// Type is the environment's type.
 	Type EnvironmentType `json:"type"`
+	// EnvironmentSlug is the immutable unique identifier (slug) of the environment, and cannot be
+	// changed after the environment is created. If not provided, a slug will be generated.
+	EnvironmentSlug *string `json:"environment_slug"`
 	// CrossOrgPasswordsEnabled indicates whether the environment should use cross-org passwords.
 	CrossOrgPasswordsEnabled *bool `json:"cross_org_passwords_enabled,omitempty"`
 	// UserImpersonationEnabled indicates whether user impersonation should be enabled for the


### PR DESCRIPTION
## Description

See title. Sets the project slug with custom user-provided value  on creation.

## Testing

- [x] Updated unit test.