### PR TITLE
Update tests to account for no autocreation of resources or environments

### DIFF
--- a/pkg/api/environments_test.go
+++ b/pkg/api/environments_test.go
@@ -30,13 +30,6 @@ func Test_EnvironmentsCreate(t *testing.T) {
 			UserImpersonationEnabled:        ptr(true),
 			ZeroDowntimeSessionMigrationURL: ptr(zeroDowntimeSessionMigrationURL),
 		})
-		t.Cleanup(func() {
-			_, err := client.Environments.Delete(ctx, environments.DeleteRequest{
-				ProjectSlug:     project.ProjectSlug,
-				EnvironmentSlug: resp.Environment.EnvironmentSlug,
-			})
-			require.NoError(t, err)
-		})
 
 		// Assert
 		assert.NoError(t, err)
@@ -64,13 +57,6 @@ func Test_EnvironmentsCreate(t *testing.T) {
 			UserLockThreshold:        ptr(userLockThreshold),
 			UserLockTTL:              ptr(userLockTTL),
 		})
-		t.Cleanup(func() {
-			_, err := client.Environments.Delete(ctx, environments.DeleteRequest{
-				ProjectSlug:     project.ProjectSlug,
-				EnvironmentSlug: resp.Environment.EnvironmentSlug,
-			})
-			require.NoError(t, err)
-		})
 
 		// Assert
 		assert.NoError(t, err)
@@ -96,13 +82,6 @@ func Test_EnvironmentsCreate(t *testing.T) {
 			IDPAuthorizationURL:                 &idpAuthorizationURL,
 			IDPDynamicClientRegistrationEnabled: ptr(true),
 			IDPDynamicClientRegistrationAccessTokenTemplateContent: ptr(idpTemplateContent),
-		})
-		t.Cleanup(func() {
-			_, err := client.Environments.Delete(ctx, environments.DeleteRequest{
-				ProjectSlug:     project.ProjectSlug,
-				EnvironmentSlug: resp.Environment.EnvironmentSlug,
-			})
-			require.NoError(t, err)
 		})
 
 		// Assert
@@ -202,9 +181,9 @@ func Test_EnvironmentsGetAll(t *testing.T) {
 
 		// Assert
 		assert.NoError(t, err)
-		// The project is created with both a live and test environment, and we additionally created a
-		// test environment, so we expect at least 3 environments to be returned.
-		assert.Equal(t, 3, len(resp.Environments))
+		// The disposable project is created with only a live environment, and we additionally created a
+		// test environment, so we expect 2 environments to be returned.
+		assert.Equal(t, 2, len(resp.Environments))
 		// Check that the created environment is in the returned list.
 		assert.True(t, hasEnvironment(resp.Environments, createEnvResp.Environment))
 	})

--- a/pkg/api/publictokens_test.go
+++ b/pkg/api/publictokens_test.go
@@ -125,8 +125,13 @@ func TestPublicTokensClient_Delete(t *testing.T) {
 		env := client.DisposableEnvironment(projects.VerticalConsumer, environments.EnvironmentTypeTest)
 		ctx := context.Background()
 
-		// Create a public token first
+		// Create 2 public tokens first. Note that you cannot delete all the public tokens in an environment.
 		createResp, err := client.PublicTokens.Create(ctx, publictokens.CreateRequest{
+			ProjectSlug:     env.ProjectSlug,
+			EnvironmentSlug: env.EnvironmentSlug,
+		})
+		require.NoError(t, err)
+		_, err = client.PublicTokens.Create(ctx, publictokens.CreateRequest{
 			ProjectSlug:     env.ProjectSlug,
 			EnvironmentSlug: env.EnvironmentSlug,
 		})

--- a/pkg/api/redirecturls_test.go
+++ b/pkg/api/redirecturls_test.go
@@ -258,10 +258,6 @@ func TestRedirectURLsClient_Get(t *testing.T) {
 					Type:      redirecturls.RedirectTypeLogin,
 					IsDefault: true,
 				},
-				{
-					Type:      redirecturls.RedirectTypeInvite,
-					IsDefault: false,
-				},
 			},
 		})
 		require.NoError(t, err)
@@ -277,7 +273,7 @@ func TestRedirectURLsClient_Get(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
 		assert.Equal(t, createResp.RedirectURL.URL, resp.RedirectURL.URL)
-		assert.Len(t, resp.RedirectURL.ValidTypes, 2)
+		assert.Len(t, resp.RedirectURL.ValidTypes, 1)
 
 		// Verify the types match
 		typeMap := make(map[redirecturls.RedirectType]bool)
@@ -285,9 +281,7 @@ func TestRedirectURLsClient_Get(t *testing.T) {
 			typeMap[validType.Type] = validType.IsDefault
 		}
 		assert.Contains(t, typeMap, redirecturls.RedirectTypeLogin)
-		assert.Contains(t, typeMap, redirecturls.RedirectTypeInvite)
 		assert.True(t, typeMap[redirecturls.RedirectTypeLogin])
-		assert.False(t, typeMap[redirecturls.RedirectTypeInvite])
 	})
 	t.Run("get existing redirect URL using query params", func(t *testing.T) {
 		// Arrange

--- a/pkg/api/secrets_test.go
+++ b/pkg/api/secrets_test.go
@@ -138,23 +138,6 @@ func TestSecretsClient_GetAllSecrets(t *testing.T) {
 			assert.True(t, secretIDs[createdSecret.SecretID], "Created secret %s not found in response", createdSecret.SecretID)
 		}
 	})
-
-	t.Run("only the default secret exists", func(t *testing.T) {
-		// Arrange
-		client := NewTestClient(t)
-		env := client.DisposableEnvironment(projects.VerticalConsumer, environments.EnvironmentTypeTest)
-		ctx := context.Background()
-
-		// Act
-		resp, err := client.Secrets.GetAll(ctx, secrets.GetAllSecretsRequest{
-			ProjectSlug:     env.ProjectSlug,
-			EnvironmentSlug: env.EnvironmentSlug,
-		})
-
-		// Assert
-		assert.NoError(t, err)
-		assert.Len(t, resp.Secrets, 1)
-	})
 }
 
 func TestSecretsClient_DeleteSecret(t *testing.T) {


### PR DESCRIPTION
We no longer autocreate environments or resources like secrets,  public tokens, and redirect urls in new projects/environments. This updates the tests to account for that different behavior.

## Testing

`make test` and tests now pass